### PR TITLE
use buildid/downloaded/language path

### DIFF
--- a/complete_run.sh
+++ b/complete_run.sh
@@ -7,10 +7,14 @@
 
 ./install_dependencies.sh
 
+export BUILDID=wiki_build_202207
+
+
 ./download_wikipedia.sh
 ./download_wikidata.sh
 ./download_wikidata_placetypes.sh
 
+# dropdb wikiprocessingdb
 ./import_wikipedia.sh
 ./import_wikidata.sh
 

--- a/download_wikidata.sh
+++ b/download_wikidata.sh
@@ -1,19 +1,43 @@
 #!/bin/bash
 
-download() {
-     echo "Downloading $1"
-     header='--header=User-Agent:Osm-search-Bot/1(https://github.com/osm-search/wikipedia-wikidata)'
-     wget --no-clobber "$header" --tries=3 "$1" 
-}
-
-
 echo "====================================================================="
 echo "Download wikidata dump tables"
 echo "====================================================================="
 
-# 114M  wikidatawiki-latest-geo_tags.sql.gz
-# 1.7G  wikidatawiki-latest-page.sql.gz
-# 1.2G  wikidatawiki-latest-wb_items_per_site.sql.gz
-download https://dumps.wikimedia.org/wikidatawiki/latest/wikidatawiki-latest-geo_tags.sql.gz
-download https://dumps.wikimedia.org/wikidatawiki/latest/wikidatawiki-latest-page.sql.gz
-download https://dumps.wikimedia.org/wikidatawiki/latest/wikidatawiki-latest-wb_items_per_site.sql.gz
+if [[ !$BUILDID ]]; then
+    BUILDID=latest
+fi
+
+# List of mirrors https://dumps.wikimedia.org/mirrors.html
+# Download using main server: 150 minutes, mirror: 40 minutes
+# HOST="dumps.wikimedia.org"
+HOST="wikimedia.bringyour.com"
+
+# Check https://wikimedia.bringyour.com/wikidatawiki/ which dates
+# are available. Actually open the directory to check if the dump
+# finished.
+DATE='20220701'
+DOWNLOADED_PATH="$BUILDID/downloaded"
+
+download() {
+    if [ -e "$2" ]; then
+        echo "file $2 already exists, skipping"
+        return
+    fi
+    echo "Downloading $1 > $2"
+    header='--header=User-Agent:Osm-search-Bot/1(https://github.com/osm-search/wikipedia-wikidata)'
+    wget -O "$2" --quiet $header --no-clobber --tries=3 "$1"
+    if [ ! -s "$2" ]; then
+        echo "downloaded file $2 is empty, please retry later"
+        rm -f "$2"
+        exit 1
+    fi
+}
+
+# 114M  downloaded/geo_tags.sql.gz
+# 1.7G  downloaded/page.sql.gz
+# 1.2G  downloaded/wb_items_per_site.sql.gz
+
+download https://$HOST/wikidatawiki/$DATE/wikidatawiki-$DATE-geo_tags.sql.gz          "$DOWNLOADED_PATH/geo_tags.sql.gz"
+download https://$HOST/wikidatawiki/$DATE/wikidatawiki-$DATE-page.sql.gz              "$DOWNLOADED_PATH/page.sql.gz"
+download https://$HOST/wikidatawiki/$DATE/wikidatawiki-$DATE-wb_items_per_site.sql.gz "$DOWNLOADED_PATH/wb_items_per_site.sql.gz"

--- a/download_wikipedia.sh
+++ b/download_wikipedia.sh
@@ -1,38 +1,64 @@
 #!/bin/bash
 
-download() {
-     echo "Downloading $1"
-     header='--header=User-Agent:Osm-search-Bot/1(https://github.com/osm-search/wikipedia-wikidata)'
-     wget --no-clobber "$header" --tries=3 "$1" 
-}
+echo "====================================================================="
+echo "Download individual wikipedia language tables dumps"
+echo "====================================================================="
+
+if [[ !$BUILDID ]]; then
+    BUILDID=latest
+fi
+
+DOWNLOADED_PATH="$BUILDID/downloaded"
+
+# List of mirrors https://dumps.wikimedia.org/mirrors.html
+# Download using main server: 150 minutes, mirror: 40 minutes
+# HOST="dumps.wikimedia.org"
+HOST="wikimedia.bringyour.com"
 
 # languages to process (refer to List of Wikipedias here: https://en.wikipedia.org/wiki/List_of_Wikipedias)
 # requires Bash 4.0
 readarray -t LANGUAGES < languages.txt
 
-echo "====================================================================="
-echo "Download individual wikipedia language tables"
-echo "====================================================================="
 
+
+download() {
+    if [ -e "$2" ]; then
+        echo "file $2 already exists, skipping"
+        return
+    fi
+    echo "Downloading $1 > $2"
+    header='--header=User-Agent:Osm-search-Bot/1(https://github.com/osm-search/wikipedia-wikidata)'
+    wget -O "$2" --quiet $header --no-clobber --tries=3 "$1"
+    if [ ! -s "$2" ]; then
+        echo "downloaded file $2 is empty, please retry later"
+        rm -f "$2"
+        exit 1
+    fi
+}
 
 for LANG in "${LANGUAGES[@]}"
 do
     echo "Language: $LANG"
 
-    # english is the largest
-    # 1.7G  enwiki-latest-page.sql.gz
-    # 6.2G  enwiki-latest-pagelinks.sql.gz
-    # 355M  enwiki-latest-langlinks.sql.gz
-    # 128M  enwiki-latest-redirect.sql.gz
+    mkdir -p "$DOWNLOADED_PATH/$LANG"
 
-    # example of smaller languge turkish
-    #  53M  trwiki-latest-page.sql.gz
-    # 176M  trwiki-latest-pagelinks.sql.gz
-    # 106M  trwiki-latest-langlinks.sql.gz
-    # 3.2M  trwiki-latest-redirect.sql.gz
+    # English is the largest
+    # 1.7G  downloaded/en/page.sql.gz
+    # 6.2G  downloaded/en/pagelinks.sql.gz
+    # 355M  downloaded/en/langlinks.sql.gz
+    # 128M  downloaded/en/redirect.sql.gz
 
-    download https://dumps.wikimedia.org/${LANG}wiki/latest/${LANG}wiki-latest-page.sql.gz
-    download https://dumps.wikimedia.org/${LANG}wiki/latest/${LANG}wiki-latest-pagelinks.sql.gz
-    download https://dumps.wikimedia.org/${LANG}wiki/latest/${LANG}wiki-latest-langlinks.sql.gz
-    download https://dumps.wikimedia.org/${LANG}wiki/latest/${LANG}wiki-latest-redirect.sql.gz
+    # Smaller language Turkish
+    #  53M  downloaded/tr/page.sql.gz
+    # 176M  downloaded/tr/pagelinks.sql.gz
+    # 106M  downloaded/tr/langlinks.sql.gz
+    # 3.2M  downloaded/tr/redirect.sql.gz
+
+    # So far we were only interested in latest
+    DATE=latest
+
+    download https://$HOST/${LANG}wiki/$DATE/${LANG}wiki-$DATE-page.sql.gz      "$DOWNLOADED_PATH/$LANG/page.sql.gz"
+    download https://$HOST/${LANG}wiki/$DATE/${LANG}wiki-$DATE-pagelinks.sql.gz "$DOWNLOADED_PATH/$LANG/pagelinks.sql.gz"
+    download https://$HOST/${LANG}wiki/$DATE/${LANG}wiki-$DATE-langlinks.sql.gz "$DOWNLOADED_PATH/$LANG/langlinks.sql.gz"
+    download https://$HOST/${LANG}wiki/$DATE/${LANG}wiki-$DATE-redirect.sql.gz  "$DOWNLOADED_PATH/$LANG/redirect.sql.gz"
 done

--- a/import_new_test.sh
+++ b/import_new_test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# psqlcmd() {
+#      psql --quiet wikiprocessingdb |& \
+#      grep -v 'does not exist, skipping' |& \
+#      grep -v 'violates check constraint' |& \
+#      grep -vi 'Failing row contains'
+# }
+
+psqlcmd() {
+     psql --quiet wikiprocessingdb
+}
+
+# languages to process (refer to List of Wikipedias here: https://en.wikipedia.org/wiki/List_of_Wikipedias)
+# requires Bash 4.0
+readarray -t LANGUAGES < languages.txt
+
+for LANG in "${LANGUAGES[@]}"
+do
+    echo "Language: $i"
+
+    # -----------------------------------------------------------
+    echo "Importing pages.csv.gz";
+
+    echo "CREATE TABLE ${LANG}page2 (
+            page_id            integer,
+            page_title         text
+        );" | psqlcmd
+
+
+    # copy newtable from program 'zcat /tmp/tp.csv.gz'
+    # zcat /tmp/newtable.csv.gz | psql -d dbname -c "copy newtable from stdin;"
+
+    echo "COPY ${LANG}page2 (page_id, page_title)
+        FROM PROGRAM 'zcat $PWD/converted/${LANG}/pages.csv.gz'
+        DELIMITER ','
+        CSV
+        ;" | psqlcmd
+
+
+
+    # -----------------------------------------------------------
+    echo "Importing pagelinks.csv.gz";
+
+    echo "CREATE TABLE ${LANG}pagelinks2 (
+            pl_title          text
+        );" | psqlcmd
+
+    echo "COPY ${LANG}pagelinks2 (pl_title)
+        FROM PROGRAM 'zcat $PWD/converted/${LANG}/pagelinks.csv.gz'
+        DELIMITER ','
+        CSV
+        ;" | psqlcmd
+
+
+    # -----------------------------------------------------------
+    echo "Importing langlinks.csv.gz";
+
+    echo "CREATE TABLE ${LANG}langlinks2 (
+            ll_from    integer,
+            ll_lang    text,
+            ll_title   text
+        );" | psqlcmd
+
+    echo "COPY ${LANG}langlinks2 (ll_title, ll_from, ll_lang)
+        FROM PROGRAM 'zcat $PWD/converted/${LANG}/langlinks.csv.gz'
+        DELIMITER ','
+        CSV
+        ;" | psqlcmd
+
+
+    # -----------------------------------------------------------
+    echo "Importing redirects.csv.gz";
+
+    echo "CREATE TABLE ${LANG}redirects2 (
+            rd_from    integer,
+            rd_title   text
+        );" | psqlcmd
+
+    echo "COPY ${LANG}redirects2 (rd_from, rd_title)
+        FROM PROGRAM 'zcat $PWD/converted/${LANG}/redirects.csv.gz'
+        DELIMITER ','
+        CSV
+        ;" | psqlcmd
+
+done

--- a/import_wikidata.sh
+++ b/import_wikidata.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ !$BUILDID ]]; then
+    BUILDID=latest
+fi
+
+DOWNLOADED_PATH="$BUILDID/downloaded"
+
 psqlcmd() {
      psql --quiet wikiprocessingdb
 }
@@ -15,14 +21,14 @@ echo "====================================================================="
 echo "Import wikidata dump tables"
 echo "====================================================================="
 
-echo "Importing wikidatawiki-latest-geo_tags"
-gzip -dc wikidatawiki-latest-geo_tags.sql.gz          | mysql2pgsqlcmd | psqlcmd
+echo "Importing geo_tags"
+gzip -dc "$DOWNLOADED_PATH/geo_tags.sql.gz"          | mysql2pgsqlcmd | psqlcmd
 
-echo "Importing wikidatawiki-latest-page"
-gzip -dc wikidatawiki-latest-page.sql.gz              | mysql2pgsqlcmd | psqlcmd
+echo "Importing page"
+gzip -dc "$DOWNLOADED_PATH/page.sql.gz"              | mysql2pgsqlcmd | psqlcmd
 
-echo "Importing wikidatawiki-latest-wb_items_per_site"
-gzip -dc wikidatawiki-latest-wb_items_per_site.sql.gz | mysql2pgsqlcmd | psqlcmd
+echo "Importing wb_items_per_site"
+gzip -dc "$DOWNLOADED_PATH/wb_items_per_site.sql.gz" | mysql2pgsqlcmd | psqlcmd
 
 
 

--- a/process_wikipedia.sh
+++ b/process_wikipedia.sh
@@ -6,6 +6,40 @@ readarray -t LANGUAGES < languages.txt
 
 
 echo "====================================================================="
+echo "Create wikipedia calculation tables"
+echo "====================================================================="
+
+echo "CREATE TABLE linkcounts (
+        language text,
+        title    text,
+        count    integer,
+        sumcount integer,
+        lat      double precision,
+        lon      double precision
+     );"  | psqlcmd
+
+echo "CREATE TABLE wikipedia_article (
+        language    text NOT NULL,
+        title       text NOT NULL,
+        langcount   integer,
+        othercount  integer,
+        totalcount  integer,
+        lat double  precision,
+        lon double  precision,
+        importance  double precision,
+        title_en    text,
+        osm_type    character(1),
+        osm_id      bigint
+      );" | psqlcmd
+
+echo "CREATE TABLE wikipedia_redirect (
+        language   text,
+        from_title text,
+        to_title   text
+     );" | psqlcmd
+
+
+echo "====================================================================="
 echo "Process language tables and associated pagelink counts"
 echo "====================================================================="
 


### PR DESCRIPTION
* Instead of downloading files into the current directory, e.g. `./enwiki-latest-langlinks.sql.gz` download into `$BUILDDIR/downloaded/$LANGUAGE/langlinks.sql.gz`. This also makes looping easier. BUILDDIR will help us to make sure all data written is in a separate path, e.g. could be on another partition or (docker) shared volume.

* use Wikimedia mirror server. That cuts down download time by almost two hours (150 vs 40 minutes). Fixes https://github.com/osm-search/wikipedia-wikidata/issues/8 For wikidata dump the mirror has no 'latest' directory, onlly dates.

* use a HTTP user agent header for the downloads as required by wikipedia policy (https://github.com/osm-search/wikipedia-wikidata/issues/3)