### PR TITLE
First complete run

### DIFF
--- a/complete_run.sh
+++ b/complete_run.sh
@@ -18,8 +18,8 @@ export DATABASE_NAME=wikiprocessingdb
 ./steps/wikipedia_sql2csv.sh
 ./steps/wikidata_sql2csv.sh
 
-# dropdb wikiprocessingdb $DATABASE_NAME
-createdb wikiprocessingdb $DATABASE_NAME
+# dropdb --if-exists $DATABASE_NAME
+createdb $DATABASE_NAME
 ./steps/wikipedia_import.sh
 ./steps/wikidata_import.sh
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -4,7 +4,7 @@
 # Tested on Ubuntu-20
 #
 
-sudo apt-get install -y wget perl coreutils nodejs
+sudo apt-get install -y wget perl coreutils nodejs jq moreutils
 
 # https://github.com/wireservice/csvkit
 # https://csvkit.readthedocs.io
@@ -13,4 +13,4 @@ pip install csvkit
 
 # https://wdtaxonomy.readthedocs.io/
 node --version
-npm install -g wikidata-taxonomy
+sudo npm install -g wikidata-taxonomy

--- a/steps/wikidata_api_fetch_placetypes.sh
+++ b/steps/wikidata_api_fetch_placetypes.sh
@@ -61,7 +61,7 @@ mkdir -p $TEMP_PATH
 
 echo "Number of place types:"
 wc -l config/wikidata_place_types.txt
-echo '' > $DOWNLOADED_PATH/wikidata_place_dump.csv
+echo -n > $DOWNLOADED_PATH/wikidata_place_dump.csv
 
 while read PT_LINE ; do
     QID=$(echo $PT_LINE | sed 's/;.*//' )

--- a/steps/wikidata_import.sh
+++ b/steps/wikidata_import.sh
@@ -9,7 +9,8 @@ DOWNLOADED_PATH="$BUILDID/downloaded/wikidata"
 DOWNLOADED_PATH_ABS=$(realpath "$DOWNLOADED_PATH")
 
 psqlcmd() {
-     psql --quiet $DATABASE_NAME
+     psql --quiet $DATABASE_NAME |& \
+     grep -v 'does not exist, skipping'
 }
 
 mysql2pgsqlcmd() {

--- a/steps/wikidata_process.sh
+++ b/steps/wikidata_process.sh
@@ -21,6 +21,7 @@ echo "====================================================================="
 echo "Create derived tables"
 echo "====================================================================="
 
+echo "DROP TABLE IF EXISTS geo_earth_primary;" | psqlcmd
 echo "CREATE TABLE geo_earth_primary AS
       SELECT gt_page_id,
              gt_lat,
@@ -36,6 +37,8 @@ echo "CREATE TABLE geo_earth_primary AS
                  OR gt_lon=0)
       ;" | psqlcmd
 
+
+echo "DROP TABLE IF EXISTS geo_earth_wikidata;" | psqlcmd
 echo "CREATE TABLE geo_earth_wikidata AS
       SELECT DISTINCT geo_earth_primary.gt_page_id,
                       geo_earth_primary.gt_lat,
@@ -60,6 +63,8 @@ echo "UPDATE wikidata_place_dump
       WHERE wikidata_place_dump.instance_of = wikidata_place_type_levels.place_type
       ;" | psqlcmd
 
+
+echo "DROP TABLE IF EXISTS wikidata_places;" | psqlcmd
 echo "CREATE TABLE wikidata_places
       AS
       SELECT DISTINCT ON (item) item,
@@ -91,6 +96,7 @@ echo "Process language pages"
 echo "====================================================================="
 
 
+echo "DROP TABLE IF EXISTS wikidata_pages;" | psqlcmd
 echo "CREATE TABLE wikidata_pages (
         item          text,
         instance_of   text,
@@ -102,6 +108,7 @@ echo "CREATE TABLE wikidata_pages (
 
 for i in "${LANGUAGES_ARRAY[@]}"
 do
+   echo "DROP TABLE IF EXISTS wikidata_${i}_pages;" | psqlcmd
    echo "CREATE TABLE wikidata_${i}_pages AS
          SELECT wikidata_places.item,
                 wikidata_places.instance_of,
@@ -162,6 +169,7 @@ echo "UPDATE wikipedia_article
         AND wikipedia_article.title  = wikidata_pages.wp_page_title
       ;" | psqlcmd
 
+echo "DROP TABLE IF EXISTS wikipedia_article_slim;" | psqlcmd
 echo "CREATE TABLE wikipedia_article_slim
       AS
       SELECT * FROM wikipedia_article

--- a/steps/wikidata_sql2csv.sh
+++ b/steps/wikidata_sql2csv.sh
@@ -156,3 +156,6 @@ gzip -9 \
 
 
 du -h $CONVERTED_PATH/*
+# 88M     geo_tags.csv.gz
+# 480M    page.csv.gz
+# 744M    wb_items_per_site.csv.gz

--- a/steps/wikidata_sql2csv.sh
+++ b/steps/wikidata_sql2csv.sh
@@ -91,7 +91,7 @@ sed 's/\r\?//g' | \
 csvcut -c 1,3,2 | \
 grep -e ',0$' | \
 sed 's/,0$//' | \
-grep -v ',Q' | \
+grep ',Q' | \
 gzip -9 \
 > $CONVERTED_PATH/page.csv.gz
 
@@ -155,4 +155,4 @@ gzip -9 \
 # 2912549,cawiki,Brúixola Brunton
 
 
-ls -lah $CONVERTED_PATH
+du -h $CONVERTED_PATH/*

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -15,6 +15,7 @@ echo "====================================================================="
 echo "Create wikipedia calculation tables"
 echo "====================================================================="
 
+echo "DROP TABLE IF EXISTS linkcounts;" | psqlcmd
 echo "CREATE TABLE linkcounts (
         language text,
         title    text,
@@ -24,6 +25,7 @@ echo "CREATE TABLE linkcounts (
         lon      double precision
      );"  | psqlcmd
 
+echo "DROP TABLE IF EXISTS wikipedia_article;" | psqlcmd
 echo "CREATE TABLE wikipedia_article (
         language    text NOT NULL,
         title       text NOT NULL,
@@ -38,6 +40,7 @@ echo "CREATE TABLE wikipedia_article (
         osm_id      bigint
       );" | psqlcmd
 
+echo "DROP TABLE IF EXISTS wikipedia_redirect;" | psqlcmd
 echo "CREATE TABLE wikipedia_redirect (
         language   text,
         from_title text,
@@ -54,6 +57,7 @@ for i in "${LANGUAGES_ARRAY[@]}"
 do
     echo "Language: $i"
 
+    echo "DROP TABLE IF EXISTS ${i}pagelinkcount;" | psqlcmd
     echo "CREATE TABLE ${i}pagelinkcount
           AS
           SELECT pl_title AS title,

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -8,7 +8,8 @@ LANGUAGES_ARRAY=($(echo $LANGUAGES | tr ',' ' '))
 
 
 psqlcmd() {
-     psql --quiet $DATABASE_NAME
+     psql --quiet $DATABASE_NAME |& \
+     grep -v 'does not exist, skipping'
 }
 
 echo "====================================================================="


### PR DESCRIPTION
First run that finished after 2 years. The last steps that writes the redirect output file was lost.

```
wikipedia_download.sh - 40 minutes
wikidata_download.sh - 20 minutes
wikipedia_api_fetch_placetypes.sh - 15 minutes
(wikipedia_sql2csv.sh - 10 hours
wikidata_sql2csv.sh - 40 minutes)
wikipedia_import.sh - 16 hours
wikidata_import.sh - 3 hours
wikipedia_process.sh - 2:15h hours
wikidata_process.sh - 30 minutes
```

Total about 34 hours requring 50GB of disc space for files and 520GB for database.

8 core server, 16GB RAM, NVMe discs. 

The output of _sql2csv scripts isn't used yet. Goal is to have the _import scripts use that data, it's filtered with less rows, less columns, less indices to make the imports faster.
