### PR TITLE
namespace is already filtered in sql2csv

### DIFF
--- a/steps/wikidata_import.sh
+++ b/steps/wikidata_import.sh
@@ -32,7 +32,6 @@ echo "CREATE TABLE geo_tags (
 
 echo "COPY geo_tags (gt_id, gt_lat, gt_lon)
     FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/geo_tags.csv.gz'
-    DELIMITER ','
     CSV
     ;" | psqlcmd
 
@@ -50,7 +49,6 @@ echo "CREATE TABLE page (
 
 echo "COPY page (page_id, page_title)
     FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/page.csv.gz'
-    DELIMITER ','
     CSV
     ;" | psqlcmd
 
@@ -68,7 +66,6 @@ echo "CREATE TABLE wb_items_per_site (
 
 echo "COPY wb_items_per_site (ips_item_id, ips_site_id, ips_site_page)
     FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/wb_items_per_site.csv.gz'
-    DELIMITER ','
     CSV
     ;" | psqlcmd
 
@@ -85,7 +82,6 @@ echo "CREATE TABLE wikidata_place_dump (
 
 echo "COPY wikidata_place_dump (item, instance_of)
       FROM '$DOWNLOADED_PATH_ABS/wikidata_place_dump.csv'
-      DELIMITER ','
       CSV
       ;" | psqlcmd
 
@@ -102,7 +98,6 @@ echo "CREATE TABLE wikidata_place_type_levels (
 
 echo "COPY wikidata_place_type_levels (place_type, level)
       FROM '$DOWNLOADED_PATH_ABS/wikidata_place_type_levels.csv'
-      DELIMITER ','
       CSV
       HEADER
       ;" | psqlcmd

--- a/steps/wikidata_process.sh
+++ b/steps/wikidata_process.sh
@@ -22,34 +22,17 @@ echo "====================================================================="
 echo "Create derived tables"
 echo "====================================================================="
 
-echo "DROP TABLE IF EXISTS geo_earth_primary;" | psqlcmd
-echo "CREATE TABLE geo_earth_primary AS
-      SELECT gt_page_id,
-             gt_lat,
-             gt_lon
-      FROM geo_tags
-      WHERE gt_globe = 'earth'
-        AND gt_primary = 1
-        AND NOT(    gt_lat < -90
-                 OR gt_lat > 90
-                 OR gt_lon < -180
-                 OR gt_lon > 180
-                 OR gt_lat=0
-                 OR gt_lon=0)
-      ;" | psqlcmd
-
 
 echo "DROP TABLE IF EXISTS geo_earth_wikidata;" | psqlcmd
 echo "CREATE TABLE geo_earth_wikidata AS
-      SELECT DISTINCT geo_earth_primary.gt_page_id,
-                      geo_earth_primary.gt_lat,
-                      geo_earth_primary.gt_lon,
-                      page.page_title,
-                      page.page_namespace
-      FROM geo_earth_primary
+      SELECT DISTINCT geo_tags.gt_page_id,
+                      geo_tags.gt_lat,
+                      geo_tags.gt_lon,
+                      page.page_title
+      FROM geo_tags
       LEFT OUTER JOIN page
-                   ON (geo_earth_primary.gt_page_id = page.page_id)
-      ORDER BY geo_earth_primary.gt_page_id
+                   ON (geo_tags.gt_page_id = page.page_id)
+      ORDER BY geo_tags.gt_page_id
       ;" | psqlcmd
 
 echo "ALTER TABLE wikidata_place_dump
@@ -159,14 +142,6 @@ echo "ALTER TABLE wikidata_pages
 echo "====================================================================="
 echo "Add wikidata to wikipedia_article table"
 echo "====================================================================="
-
-echo "ALTER TABLE wikipedia_article
-      ADD COLUMN wd_page_title text
-      ;" | psqlcmd
-
-echo "ALTER TABLE wikipedia_article
-      ADD COLUMN instance_of text
-      ;" | psqlcmd
 
 echo "UPDATE wikipedia_article
       SET lat = wikidata_pages.lat,

--- a/steps/wikipedia_import.sh
+++ b/steps/wikipedia_import.sh
@@ -35,7 +35,6 @@ do
 
     echo "COPY ${LANG}page (page_id, page_title)
         FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/${LANG}/pages.csv.gz'
-        DELIMITER ','
         CSV
         ;" | psqlcmd
 
@@ -51,7 +50,6 @@ do
 
     echo "COPY ${LANG}pagelinks (pl_title)
         FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/${LANG}/pagelinks.csv.gz'
-        DELIMITER ','
         CSV
         ;" | psqlcmd
 
@@ -68,7 +66,6 @@ do
 
     echo "COPY ${LANG}langlinks (ll_title, ll_from, ll_lang)
         FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/${LANG}/langlinks.csv.gz'
-        DELIMITER ','
         CSV
         ;" | psqlcmd
 
@@ -84,7 +81,6 @@ do
 
     echo "COPY ${LANG}redirect (rd_from, rd_title)
         FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/${LANG}/redirect.csv.gz'
-        DELIMITER ','
         CSV
         ;" | psqlcmd
 

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -26,20 +26,25 @@ echo "CREATE TABLE linkcounts (
         lon      double precision
      );"  | psqlcmd
 
+# osm_type, osm_id will never be filled and Nominatim doesn't use them
 echo "DROP TABLE IF EXISTS wikipedia_article;" | psqlcmd
 echo "CREATE TABLE wikipedia_article (
-        language    text NOT NULL,
-        title       text NOT NULL,
-        langcount   integer,
-        othercount  integer,
-        totalcount  integer,
-        lat double  precision,
-        lon double  precision,
-        importance  double precision,
-        title_en    text,
-        osm_type    character(1),
-        osm_id      bigint
+        language       text NOT NULL,
+        title          text NOT NULL,
+        langcount      integer,
+        othercount     integer,
+        totalcount     integer,
+        lat            double  precision,
+        lon            double  precision,
+        importance     double precision,
+        title_en       text,
+        osm_type       character(1),
+        osm_id         bigint,
+        wd_page_title  text,
+        instance_of    text
       );" | psqlcmd
+
+
 
 echo "DROP TABLE IF EXISTS wikipedia_redirect;" | psqlcmd
 echo "CREATE TABLE wikipedia_redirect (
@@ -65,7 +70,6 @@ do
                  COUNT(*) AS count,
                  0::bigint as othercount
           FROM ${LANG}pagelinks
-          WHERE pl_namespace = 0
           GROUP BY pl_title
           ;" | psqlcmd
 
@@ -74,7 +78,6 @@ do
                  pl_title,
                  COUNT(*)
           FROM ${i}pagelinks
-          WHERE pl_namespace = 0
           GROUP BY pl_title
           ;" | psqlcmd
 
@@ -84,8 +87,6 @@ do
                  rd_title
           FROM ${LANG}redirect
           JOIN ${LANG}page ON (rd_from = page_id)
-          WHERE page_namespace = 0
-            AND rd_namespace = 0
           ;" | psqlcmd
 
 done


### PR DESCRIPTION
* Three SQL queries have a namespace WHERE clause but those columns no longer exists. namespace is already filtered in the sql2csv step

* `geo_earth_primary` table is not needed. It's essentially `geo_tags` with namespace and invalid coordinates filtered. We already filter those in sql2csv step

* two columns get added to `wikipedia_article` table. That can be merged with the earlier table creation

* default delimiter for `COPY FROM ... CSV` is comma, no need to specify it explicitly
