### PR TITLE
fixes after second complete run

### DIFF
--- a/bin/round_coordinates.py
+++ b/bin/round_coordinates.py
@@ -13,11 +13,11 @@ for row in reader:
     lon = float(row['lon'])
 
     if (row['lat'] == 0 and row['lon'] == 0):
-        print('skipping 0,0', file=sys.stderr)
+        # print('skipping 0,0', file=sys.stderr)
         continue
 
     if (lat < -90 or lat > 90 or lon < -180 or lon > 180):
-        print('skipping out of bounds', file=sys.stderr)
+        # print('skipping out of bounds', file=sys.stderr)
         # print(lat, file=sys.stderr)
         # print(lon, file=sys.stderr)
         continue

--- a/steps/output.sh
+++ b/steps/output.sh
@@ -12,7 +12,8 @@ chmod 777 "$OUTPUT_PATH"
 OUTPUT_PATH_ABS=$(realpath "$OUTPUT_PATH")
 
 psqlcmd() {
-     psql --quiet $DATABASE_NAME
+     psql --quiet $DATABASE_NAME |& \
+     grep -v 'does not exist, skipping'
 }
 
 

--- a/steps/wikidata_import.sh
+++ b/steps/wikidata_import.sh
@@ -4,8 +4,10 @@
 : ${BUILDID:=latest}
 : ${DATABASE_NAME:=wikiprocessingdb}
 
+DOWNLOADED_PATH="$BUILDID/downloaded/wikidata"
 CONVERTED_PATH="$BUILDID/converted/wikidata"
 # postgresql's COPY requires full path
+DOWNLOADED_PATH_ABS=$(realpath "$DOWNLOADED_PATH")
 CONVERTED_PATH_ABS=$(realpath "$CONVERTED_PATH")
 
 psqlcmd() {
@@ -20,17 +22,17 @@ echo "====================================================================="
 
 
 # -----------------------------------------------------------
-echo "Importing geo_tags.csv.gz";
+echo "Importing geotags from $CONVERTED_PATH_ABS/geo_tags.csv.gz";
 
 echo "DROP TABLE IF EXISTS geo_tags;" | psqlcmd
 echo "CREATE TABLE geo_tags (
-        gt_id         bigint,
+        gt_page_id    bigint,
         gt_lat        numeric(11,8),
         gt_lon        numeric(11,8)
     );" | psqlcmd
 
 
-echo "COPY geo_tags (gt_id, gt_lat, gt_lon)
+echo "COPY geo_tags (gt_page_id, gt_lat, gt_lon)
     FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/geo_tags.csv.gz'
     CSV
     ;" | psqlcmd
@@ -38,7 +40,7 @@ echo "COPY geo_tags (gt_id, gt_lat, gt_lon)
 
 
 # -----------------------------------------------------------
-echo "Importing page.csv.gz";
+echo "Importing page from $CONVERTED_PATH_ABS/page.csv.gz";
 
 echo "DROP TABLE IF EXISTS page;" | psqlcmd
 echo "CREATE TABLE page (
@@ -55,7 +57,7 @@ echo "COPY page (page_id, page_title)
 
 
 # -----------------------------------------------------------
-echo "Importing wb_items_per_site.csv.gz";
+echo "Importing wb_items_per_site from $CONVERTED_PATH_ABS/wb_items_per_site.csv.gz";
 
 echo "DROP TABLE IF EXISTS wb_items_per_site;" | psqlcmd
 echo "CREATE TABLE wb_items_per_site (
@@ -72,7 +74,7 @@ echo "COPY wb_items_per_site (ips_item_id, ips_site_id, ips_site_page)
 
 
 # -----------------------------------------------------------
-echo "Importing wikidata_place_dump.csv";
+echo "Importing wikidata_place_dump from $DOWNLOADED_PATH_ABS/wikidata_place_dump.csv";
 
 echo "DROP TABLE IF EXISTS wikidata_place_dump;" | psqlcmd
 echo "CREATE TABLE wikidata_place_dump (
@@ -88,12 +90,12 @@ echo "COPY wikidata_place_dump (item, instance_of)
 
 
 # -----------------------------------------------------------
-echo "Importing wikidata_place_type_levels.csv";
+echo "Importing wikidata_place_type_levels from $DOWNLOADED_PATH_ABS/wikidata_place_type_levels.csv";
 
 echo "DROP TABLE IF EXISTS wikidata_place_type_levels;" | psqlcmd
 echo "CREATE TABLE wikidata_place_type_levels (
-        place_type text,
-        level      integer
+        place_type    text,
+        level         integer
       );" | psqlcmd
 
 echo "COPY wikidata_place_type_levels (place_type, level)

--- a/steps/wikidata_process.sh
+++ b/steps/wikidata_process.sh
@@ -86,7 +86,7 @@ echo "CREATE TABLE wikidata_pages (
         instance_of   text,
         lat           numeric(11,8),
         lon           numeric(11,8),
-        ips_site_page text,
+        wp_page_title text,
         language      text
       );" | psqlcmd
 
@@ -103,16 +103,7 @@ do
          LEFT JOIN wb_items_per_site
                 ON (CAST (( LTRIM(wikidata_places.item, 'Q')) AS INTEGER) = wb_items_per_site.ips_item_id)
          WHERE ips_site_id = '${LANG}wiki'
-           AND LEFT(wikidata_places.item,1) = 'Q'
          ORDER BY wikidata_places.item
-         ;" | psqlcmd
-
-   echo "ALTER TABLE wikidata_${LANG}_pages
-         ADD COLUMN language text
-         ;" | psqlcmd
-
-   echo "UPDATE wikidata_${LANG}_pages
-         SET language = '${LANG}'
          ;" | psqlcmd
 
    echo "INSERT INTO wikidata_pages
@@ -120,21 +111,11 @@ do
                 instance_of,
                 lat,
                 lon,
-                ips_site_page,
-                language
+                REPLACE(ips_site_page, ' ', '_') as wp_page_title,
+                '${LANG}'
          FROM wikidata_${LANG}_pages
          ;" | psqlcmd
 done
-
-echo "ALTER TABLE wikidata_pages
-      ADD COLUMN wp_page_title text
-      ;" | psqlcmd
-echo "UPDATE wikidata_pages
-      SET wp_page_title = REPLACE(ips_site_page, ' ', '_')
-      ;" | psqlcmd
-echo "ALTER TABLE wikidata_pages
-      DROP COLUMN ips_site_page
-      ;" | psqlcmd
 
 
 

--- a/steps/wikidata_sql2csv.sh
+++ b/steps/wikidata_sql2csv.sh
@@ -49,7 +49,7 @@ gzip -9 \
 # Output
 #   89 MB (240 MB uncompressed)
 #   8.4m entries
-#   columns: page_id, lat, lon
+#   columns: gt_page_id, gt_lat, gt_lon
 # 4175,43.1924,-81.3158
 # 4180,-26.0,121.0
 # 4181,43.08333333,2.41666667

--- a/steps/wikipedia_import.sh
+++ b/steps/wikipedia_import.sh
@@ -24,7 +24,7 @@ do
     echo "Language: $LANG"
 
     # -----------------------------------------------------------
-    echo "Importing pages.csv.gz";
+    echo "Importing ${LANG}page from $CONVERTED_PATH_ABS/$LANG/pages.csv.gz";
 
     echo "DROP TABLE IF EXISTS ${LANG}page;" | psqlcmd
     echo "CREATE TABLE ${LANG}page (
@@ -34,14 +34,14 @@ do
 
 
     echo "COPY ${LANG}page (page_id, page_title)
-        FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/${LANG}/pages.csv.gz'
+        FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/$LANG/pages.csv.gz'
         CSV
         ;" | psqlcmd
 
 
 
     # -----------------------------------------------------------
-    echo "Importing pagelinks.csv.gz";
+    echo "Importing ${LANG}pagelinks from $CONVERTED_PATH_ABS/$LANG/pagelinks.csv.gz";
 
     echo "DROP TABLE IF EXISTS ${LANG}pagelinks;" | psqlcmd
     echo "CREATE TABLE ${LANG}pagelinks (
@@ -49,13 +49,13 @@ do
         );" | psqlcmd
 
     echo "COPY ${LANG}pagelinks (pl_title)
-        FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/${LANG}/pagelinks.csv.gz'
+        FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/$LANG/pagelinks.csv.gz'
         CSV
         ;" | psqlcmd
 
 
     # -----------------------------------------------------------
-    echo "Importing langlinks.csv.gz";
+    echo "Importing ${LANG}langlinks from $CONVERTED_PATH_ABS/$LANG/langlinks.csv.gz";
 
     echo "DROP TABLE IF EXISTS ${LANG}langlinks;" | psqlcmd
     echo "CREATE TABLE ${LANG}langlinks (
@@ -65,13 +65,13 @@ do
         );" | psqlcmd
 
     echo "COPY ${LANG}langlinks (ll_title, ll_from, ll_lang)
-        FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/${LANG}/langlinks.csv.gz'
+        FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/$LANG/langlinks.csv.gz'
         CSV
         ;" | psqlcmd
 
 
     # -----------------------------------------------------------
-    echo "Importing redirects.csv.gz";
+    echo "Importing ${LANG}redirect from $CONVERTED_PATH_ABS/$LANG/redirects.csv.gz";
 
     echo "DROP TABLE IF EXISTS ${LANG}redirect;" | psqlcmd
     echo "CREATE TABLE ${LANG}redirect (
@@ -80,7 +80,7 @@ do
         );" | psqlcmd
 
     echo "COPY ${LANG}redirect (rd_from, rd_title)
-        FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/${LANG}/redirect.csv.gz'
+        FROM PROGRAM 'zcat $CONVERTED_PATH_ABS/$LANG/redirect.csv.gz'
         CSV
         ;" | psqlcmd
 

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -61,7 +61,7 @@ echo "====================================================================="
 
 for LANG in "${LANGUAGES_ARRAY[@]}"
 do
-    echo "Language: $i"
+    echo "Language: $LANG"
 
     echo "DROP TABLE IF EXISTS ${LANG}pagelinkcount;" | psqlcmd
     echo "CREATE TABLE ${LANG}pagelinkcount


### PR DESCRIPTION
Runtime under 12 hours and less than 200GB database size are excellent news. Some tables were not created correctly and I'm sure some database indices should be added but it's a major step in the right direction.

* silence `round_coordinates.py`. There's only about 120 "skipping out of bounds" total

* `wikidata_place_dump.csv` and `wikidata_place_type_levels.csv` are in the download directory, not convert directory

* `geo_tags` table column `gt_id` should be `gt_pageid`. Data itself was fine

```sql
ALTER TABLE wikidata_${LANG}_pages ADD COLUMN language text;
UPDATE wikidata_${LANG}_pages SET language = '${LANG}';
```
... can be shortened by adding the column during page creation.