### PR TITLE
mysqldump_to_csv: invalid utf8 should not throw exception

### DIFF
--- a/bin/mysqldump_to_csv.py
+++ b/bin/mysqldump_to_csv.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-import fileinput
+# import fileinput
 import csv
 import sys
+import io
 
 # This prevents prematurely closed pipes from raising
 # an exception in Python
@@ -101,12 +102,16 @@ def main():
     # listed in sys.argv[1:]
     # or stdin if no args given.
     try:
-        for line in fileinput.input():
-            # Look for an INSERT statement and parse it.
-            if is_insert(line):
-                values = get_values(line)
-                if values_sanity_check(values):
-                    parse_values(values, sys.stdout)
+        # UPDATE: fileinput starts supporting 'errors' in Python 5.10. Until then
+        # call io.open() directly.
+        # for line in fileinput.input():
+        with io.open(sys.stdin.fileno(), 'r', encoding="utf-8", errors="surrogateescape") as file:
+            for line in file:
+                # Look for an INSERT statement and parse it.
+                if is_insert(line):
+                    values = get_values(line)
+                    if values_sanity_check(values):
+                        parse_values(values, sys.stdout)
     except KeyboardInterrupt:
         sys.exit(0)
 

--- a/bin/mysqldump_to_csv.readme.txt
+++ b/bin/mysqldump_to_csv.readme.txt
@@ -1,1 +1,3 @@
 https://github.com/jamesmishra/mysqldump-to-csv
+
+* Added errors=surrogateescape to open(), otherwise the script threw UnicodeDecodeError for langlinks files


### PR DESCRIPTION
`mysqldump_to_csv.py` uses `fileinput` module but only starting Python 3.10 that supports handling or ignoring invalid utf8. Switched to use `open()` in the meantime.