### PR TITLE
Ignoring unicode in mysqldump_to_csv caused empty lines in pagelinks.csv.gz

### DIFF
--- a/bin/mysqldump_to_csv.py
+++ b/bin/mysqldump_to_csv.py
@@ -105,7 +105,7 @@ def main():
         # UPDATE: fileinput starts supporting 'errors' in Python 5.10. Until then
         # call io.open() directly.
         # for line in fileinput.input():
-        with io.open(sys.stdin.fileno(), 'r', encoding="utf-8", errors="surrogateescape") as file:
+        with io.open(sys.stdin.fileno(), 'r', encoding="utf-8", errors="ignore") as file:
             for line in file:
                 # Look for an INSERT statement and parse it.
                 if is_insert(line):

--- a/steps/wikipedia_sql2csv.sh
+++ b/steps/wikipedia_sql2csv.sh
@@ -68,6 +68,7 @@ do
     csvcut -c 3,2 | \
     grep -e ',0$' | \
     sed 's/,0$//' | \
+    grep -v '^$' | \
     gzip -9 > $CONVERTED_PATH/$LANG/pagelinks.csv.gz
 
 


### PR DESCRIPTION
Ignoring unicode in `mysqldump_to_csv` caused empty lines in `pagelinks.csv.gz` and later `ERROR:  null value in column "title" violates not-null constraint`