### PR TITLE
output COPY dumped the wrong table

### DIFF
--- a/steps/output.sh
+++ b/steps/output.sh
@@ -145,7 +145,7 @@ echo "COPY wikipedia_redirect
 echo "* wikimedia_importance.csv.gz"
 
 rm -f "$OUTPUT_PATH_ABS/wikimedia_importance.csv.gz"
-echo "COPY wikipedia_redirect
+echo "COPY wikimedia_importance
       TO PROGRAM 'pigz -9 > $OUTPUT_PATH_ABS/wikimedia_importance.csv.gz'
       CSV
       HEADER;" | psqlcmd


### PR DESCRIPTION
Wrong table was dumped into wikimedia_importance.csv.gz, copy&paste error. Thanks lonvia (https://github.com/osm-search/wikipedia-wikidata/pull/42#pullrequestreview-1051558586)