### PR TITLE
set a minimum importance (not 0)

### DIFF
--- a/steps/output.sh
+++ b/steps/output.sh
@@ -42,7 +42,7 @@ echo "CREATE TABLE wikipedia_article
 # 9.2m rows
 
 echo "* wikipedia_redirect (Less rows than wikipedia_redirect_full)"
-# Remove rows that don't point to titles in wikidata_article)"
+# Remove rows that don't point to titles in wikipedia_article)"
 
 echo "DROP TABLE IF EXISTS wikipedia_redirect;" | psqlcmd
 echo "CREATE TABLE wikipedia_redirect
@@ -151,7 +151,7 @@ echo "COPY wikimedia_importance
       HEADER;" | psqlcmd
 
 # postgresql owns the files it dumps via COPY
-chown "$USER" $OUTPUT_PATH/*.gz
+sudo chown "$USER" $OUTPUT_PATH/*.gz
 
 du -h $OUTPUT_PATH/*
 # 220M  wikipedia_article.csv.gz

--- a/steps/wikidata_process.sh
+++ b/steps/wikidata_process.sh
@@ -138,3 +138,21 @@ echo "UPDATE wikipedia_article_full
 # 166m rows
 
 
+echo "====================================================================="
+echo "Calculate importance score for each wikipedia page"
+echo "====================================================================="
+
+# takes 3 minutes
+# 'greatest' because log(1)/<any number> is always 0
+echo "UPDATE wikipedia_article_full
+      SET importance = GREATEST(
+                          LOG(totalcount)
+                          /
+                          LOG((
+                            SELECT MAX(totalcount)
+                            FROM wikipedia_article_full
+                            WHERE wd_page_title IS NOT NULL
+                          )),
+                          0.0000000001
+                       )
+      ;" | psqlcmd

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -134,16 +134,6 @@ do
 done
 
 
-
-echo "====================================================================="
-echo "Calculate importance score for each wikipedia page"
-echo "====================================================================="
-
-# takes 3 minutes
-echo "UPDATE wikipedia_article_full
-      SET importance = LOG(totalcount)/LOG((SELECT MAX(totalcount) FROM wikipedia_article_full))
-      ;" | psqlcmd
-
 echo "done"
 
 


### PR DESCRIPTION
- `log(1)/<any number>` is 0 so any wikipedia article without any links to it had importance = 0. That just means it's less important but let's avoid 0 because that might be read/confused later as 'unknown'
- when looking at maximum `total_count` exclude articles with special prefixes (`WP:...`) and some categories (`animal`). Now the article with the highest `total_count` is the country France. That required the logic to move to `steps/process_wikidata.sh`

fixes https://github.com/osm-search/wikipedia-wikidata/issues/48 and https://github.com/osm-search/wikipedia-wikidata/issues/43