### PR TITLE
Python CSV library started croaking and needs escapechar set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install PostgreSQL
       run: |
         sudo apt-get update -qq
@@ -29,6 +29,9 @@ jobs:
         ./steps/wikidata_api_fetch_placetypes.sh
       env:
         BUILDID: ci_test_build
+        WIKIPEDIA_DATE: 20230201
+        WIKIDATA_DATE: 20230201
         LANGUAGES: li,bar
+
     - name: Test output
       run: tests/run.sh

--- a/bin/mysqldump_to_csv.py
+++ b/bin/mysqldump_to_csv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # import fileinput
 import csv
 import sys
@@ -50,7 +50,7 @@ def parse_values(values, outfile):
                         strict=True
     )
 
-    writer = csv.writer(outfile, quoting=csv.QUOTE_MINIMAL)
+    writer = csv.writer(outfile, quoting=csv.QUOTE_MINIMAL, escapechar='\\')
     for reader_row in reader:
         for column in reader_row:
             # If our current string is empty...

--- a/bin/mysqldump_to_csv.readme.txt
+++ b/bin/mysqldump_to_csv.readme.txt
@@ -1,3 +1,5 @@
 https://github.com/jamesmishra/mysqldump-to-csv
 
 * Added errors=surrogateescape to open(), otherwise the script threw UnicodeDecodeError for langlinks files
+* Use python3 in first line
+* Explicitly set escapechar for csv.writer

--- a/complete_run.sh
+++ b/complete_run.sh
@@ -4,12 +4,19 @@
 # Single script to do all processing from scratch. Run it or
 # use as guide how to run the individual steps.
 #
+# Example to add timestamps and create a logfile:
+# time ./complete_run.sh 2>&1 | ts -s "[%H:%M:%S]" | tee "$(date +"%Y%m%d").$$.log"
+
 
 ./install_dependencies.sh
 
-export BUILDID=wiki_build_20220620
+export BUILDID=wiki_build_20230201c
+export WIKIPEDIA_DATE=20230201 # check https://wikimedia.bringyour.com/enwiki/
+export WIKIDATA_DATE=20230201 # check https://wikimedia.bringyour.com/wikidatawiki/
 export LANGUAGES=$(grep -v '^#' config/languages.txt | tr "\n" ",")
-export DATABASE_NAME=wikiprocessingdb
+# export LANGUAGES=de,nl
+export DATABASE_NAME=$BUILDID
+export DATABASE_TABLESPACE=extraspace # default is pg_default
 
 ./steps/wikipedia_download.sh
 ./steps/wikidata_download.sh
@@ -19,7 +26,7 @@ export DATABASE_NAME=wikiprocessingdb
 ./steps/wikidata_sql2csv.sh
 
 # dropdb --if-exists $DATABASE_NAME
-createdb $DATABASE_NAME
+createdb --tablespace=extraspace $DATABASE_NAME
 ./steps/wikipedia_import.sh
 ./steps/wikidata_import.sh
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
 
 #
-# Tested on Ubuntu-20
+# Tested on Ubuntu-22
 #
+
+sudo apt-get install -y postgresql-14
+sudo -u postgres createuser -s $USER
+
+# The database can be 100GB or more. If you want to create it on a separate
+# drive you can try:
+#
+# sudo -u postgres psql -c 'SELECT * FROM pg_tablespace;'
+# # oid  |  spcname   | spcowner | spcacl | spcoptions
+# #------+------------+----------+--------+------------
+# # 1663 | pg_default |       10 |        |
+# # 1664 | pg_global  |       10 |        |
+#
+# EXTRASPACE_PATH=/mnt/HC_Volume_21300566/postgres-data
+# sudo mkdir -p $EXTRASPACE_PATH
+# sudo chown postgres $EXTRASPACE_PATH
+# sudo chgrp postgres $EXTRASPACE_PATH
+#
+# sudo -u postgres psql -c "CREATE TABLESPACE extraspace LOCATION '$EXTRASPACE_PATH';"
+# sudo -u postgres psql -c 'SELECT * FROM pg_tablespace;'
+
+
 
 sudo apt-get install -y wget coreutils nodejs jq moreutils pigz
 

--- a/steps/wikidata_api_fetch_placetypes.sh
+++ b/steps/wikidata_api_fetch_placetypes.sh
@@ -6,6 +6,11 @@
 DOWNLOADED_PATH="$BUILDID/downloaded/wikidata"
 TEMP_PATH=$DOWNLOADED_PATH/tmp
 
+if [[ -e $DOWNLOADED_PATH/wikidata_place_dump.csv.gz ]]; then
+    echo "Output file $DOWNLOADED_PATH/wikidata_place_dump.csv.gz already exists. Won't fetch again."
+    exit 0
+fi
+
 echo "====================================================================="
 echo "Get wikidata places from wikidata query API"
 echo "====================================================================="

--- a/steps/wikidata_download.sh
+++ b/steps/wikidata_download.sh
@@ -10,7 +10,7 @@ echo "====================================================================="
 # Download using main dumps.wikimedia.org: 60 minutes, mirror: 20 minutes
 : ${WIKIMEDIA_HOST:=wikimedia.bringyour.com}
 # See list on https://wikimedia.bringyour.com/wikidatawiki/
-: ${WIKIDATA_DATE:=20220620}
+: ${WIKIDATA_DATE:=20220701}
 
 
 DOWNLOADED_PATH="$BUILDID/downloaded/wikidata"

--- a/steps/wikipedia_download.sh
+++ b/steps/wikipedia_download.sh
@@ -12,7 +12,7 @@ LANGUAGES_ARRAY=($(echo $LANGUAGES | tr ',' ' '))
 # List of mirrors https://dumps.wikimedia.org/mirrors.html
 # Download using main dumps.wikimedia.org: 150 minutes, mirror: 40 minutes
 : ${WIKIMEDIA_HOST:=wikimedia.bringyour.com}
-# See list on https://wikimedia.bringyour.com/wikidatawiki/
+# See list on https://wikimedia.bringyour.com/enwiki/
 : ${WIKIPEDIA_DATE:=20220620}
 
 

--- a/steps/wikipedia_import.sh
+++ b/steps/wikipedia_import.sh
@@ -21,10 +21,10 @@ echo "====================================================================="
 
 for LANG in "${LANGUAGES_ARRAY[@]}"
 do
-    echo "Language: $LANG"
+    echo "$LANG"
 
     # -----------------------------------------------------------
-    echo "Importing ${LANG}page from $CONVERTED_PATH_ABS/$LANG/pages.csv.gz";
+    echo "* ${LANG}page from $CONVERTED_PATH_ABS/$LANG/pages.csv.gz";
 
     echo "DROP TABLE IF EXISTS ${LANG}page;" | psqlcmd
     echo "CREATE TABLE ${LANG}page (
@@ -41,7 +41,7 @@ do
 
 
     # -----------------------------------------------------------
-    echo "Importing ${LANG}pagelinks from $CONVERTED_PATH_ABS/$LANG/pagelinks.csv.gz";
+    echo "* ${LANG}pagelinks from $CONVERTED_PATH_ABS/$LANG/pagelinks.csv.gz";
 
     echo "DROP TABLE IF EXISTS ${LANG}pagelinks;" | psqlcmd
     echo "CREATE TABLE ${LANG}pagelinks (
@@ -55,7 +55,7 @@ do
 
 
     # -----------------------------------------------------------
-    echo "Importing ${LANG}langlinks from $CONVERTED_PATH_ABS/$LANG/langlinks.csv.gz";
+    echo "* ${LANG}langlinks from $CONVERTED_PATH_ABS/$LANG/langlinks.csv.gz";
 
     echo "DROP TABLE IF EXISTS ${LANG}langlinks;" | psqlcmd
     echo "CREATE TABLE ${LANG}langlinks (
@@ -71,7 +71,7 @@ do
 
 
     # -----------------------------------------------------------
-    echo "Importing ${LANG}redirect from $CONVERTED_PATH_ABS/$LANG/redirects.csv.gz";
+    echo "* ${LANG}redirect from $CONVERTED_PATH_ABS/$LANG/redirects.csv.gz";
 
     echo "DROP TABLE IF EXISTS ${LANG}redirect;" | psqlcmd
     echo "CREATE TABLE ${LANG}redirect (

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -73,7 +73,10 @@ do
           ;" | psqlcmd
 done
 
-echo "updates"
+
+echo "add underscores to langlinks.ll_title"
+# langlinks table contain titles with spaces, e.g. 'one (two)' while pages and
+# pagelinkcount table contain titles with underscore, e.g. 'one_(two)'
 for LANG in "${LANGUAGES_ARRAY[@]}"
 do
     echo "UPDATE ${LANG}langlinks SET ll_title = REPLACE(ll_title, ' ', '_')
@@ -87,8 +90,8 @@ do
 
     for OTHERLANG in "${LANGUAGES_ARRAY[@]}"
     do
-        # langlinks table contain titles with spaces, e.g. 'one (two)' while pages and
-        # pagelinkcount table contain titles with underscore, e.g. 'one_(two)'
+        # Creating indexes on title, ll_title didn't have any positive effect on
+        # query performance and added another 35GB of data.
         echo "UPDATE ${LANG}pagelinkcount
               SET othercount = othercount + x.count
               FROM (


### PR DESCRIPTION
* Python CSV library started failing with `_csv.Error: need to escape, but no escapechar set`. Not sure why, the library hasn't changed. Maybe the script used to run under python 2 (Ubuntu 20), not it's python3 (Ubuntu 22)
* Document how I created tablespace on an external drive (database is 300GB size)
* Move setting `WIKIDATA_DATE` variable to `complete_run.sh`
* `steps/wikidata_api_fetch_placetypes.sh` should not re-download if the output file already exists. That's similar to the other download scripts we use.