### PR TITLE
sort output, 20% reduction in filesize

### DIFF
--- a/steps/output.sh
+++ b/steps/output.sh
@@ -128,6 +128,7 @@ do
 
       echo "COPY $TABLE TO STDOUT CSV HEADER;" | \
             psqlcmd | \
+            sort | \
             pigz -9 > "$OUTPUT_PATH/$TABLE.csv.gz"
 
       # default is 600


### PR DESCRIPTION
This leads to 25% file size reduction (334->252 MB) for `wikimedia_importance.csv.gz` and 20% across all 4 files.
