### PR TITLE
mysqldump_to_csv - we can treat NULL as empty string

### DIFF
--- a/bin/mysqldump_to_csv.py
+++ b/bin/mysqldump_to_csv.py
@@ -55,7 +55,8 @@ def parse_values(values, outfile):
         for column in reader_row:
             # If our current string is empty...
             if len(column) == 0 or column == 'NULL':
-                latest_row.append(chr(0))
+                # latest_row.append(chr(0))
+                latest_row.append('')
                 continue
             # If our string starts with an open paren
             if column[0] == "(":

--- a/bin/mysqldump_to_csv.readme.txt
+++ b/bin/mysqldump_to_csv.readme.txt
@@ -3,3 +3,4 @@ https://github.com/jamesmishra/mysqldump-to-csv
 * Added errors=surrogateescape to open(), otherwise the script threw UnicodeDecodeError for langlinks files
 * Use python3 in first line
 * Explicitly set escapechar for csv.writer
+* Don't print \x0 for NULL values, print '' instead.

--- a/steps/wikidata_sql2csv.sh
+++ b/steps/wikidata_sql2csv.sh
@@ -36,7 +36,6 @@ echo "wikidata_sql2csv geo_tags"
 # Round the coordinates
 unpigz -c $DOWNLOADED_PATH/geo_tags.sql.gz | \
 python3 bin/mysqldump_to_csv.py | \
-sed 's/\x0//g' | \
 bin/filter_wikidata_geo_tags.py | \
 pigz -9 \
 > $CONVERTED_PATH/geo_tags.csv.gz
@@ -83,7 +82,6 @@ echo "wikidata_sql2csv page"
 
 unpigz -c $DOWNLOADED_PATH/page.sql.gz | \
 python3 bin/mysqldump_to_csv.py | \
-sed 's/\x0//g' | \
 bin/filter_wikidata_page.py | \
 pigz -9 \
 > $CONVERTED_PATH/page.csv.gz
@@ -129,7 +127,6 @@ echo "wikidata_sql2csv wb_items_per_site"
 
 unpigz -c $DOWNLOADED_PATH/wb_items_per_site.sql.gz | \
 python3 bin/mysqldump_to_csv.py | \
-sed 's/\x0//g' | \
 bin/filter_wikidata_wb_items_per_site.py | \
 pigz -9 \
 > $CONVERTED_PATH/wb_items_per_site.csv.gz

--- a/steps/wikipedia_sql2csv.sh
+++ b/steps/wikipedia_sql2csv.sh
@@ -40,7 +40,6 @@ do
 
     unpigz -c $DOWNLOADED_PATH/${LANG}/page.sql.gz | \
     python3 bin/mysqldump_to_csv.py | \
-    sed 's/\x0//g' | \
     bin/filter_page.py | \
     pigz -9 > $CONVERTED_PATH/$LANG/pages.csv.gz
 
@@ -60,7 +59,6 @@ do
 
     unpigz -c $DOWNLOADED_PATH/${LANG}/pagelinks.sql.gz | \
     python3 bin/mysqldump_to_csv.py | \
-    sed 's/\x0//g' | \
     bin/filter_pagelinks.py | \
     pigz -9 > $CONVERTED_PATH/$LANG/pagelinks.csv.gz
 
@@ -79,7 +77,6 @@ do
 
     unpigz -c $DOWNLOADED_PATH/${LANG}/langlinks.sql.gz | \
     python3 bin/mysqldump_to_csv.py | \
-    sed 's/\x0//g' | \
     bin/filter_langlinks.py | \
     pigz -9 > $CONVERTED_PATH/$LANG/langlinks.csv.gz
 
@@ -100,7 +97,6 @@ do
 
     unpigz -c $DOWNLOADED_PATH/${LANG}/redirect.sql.gz | \
     python3 bin/mysqldump_to_csv.py | \
-    sed 's/\x0//g' | \
     bin/filter_redirect.py | \
     pigz -9 > $CONVERTED_PATH/$LANG/redirect.csv.gz
 


### PR DESCRIPTION
`mysqldump_to_csv` by default prints NULL values as \x0 (chr(0). Python's CSV library croaks on \x0. We don't need any special handling of NULL so empty string is fine with us. 