### PR TITLE
count pagelinks already in sql2csv step

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ in the results match the search terms).
 
 Wikipedia publishes [dumps](https://meta.wikimedia.org/wiki/Data_dumps) of their databases once per month.
 
-To run one build you need 420GB of disc space (of which 360GB Postgresql database). The scripts process
+To run one build you need 240GB of disc space (of which 180GB Postgresql database). The scripts process
 39 languages and output 4 files. Runtime is approximately 13 hours on a 4 core, 4GB RAM machine with SSD
 discs.
 
@@ -268,7 +268,7 @@ uncommon for an export starting Jan/1st to only be full ready Jan/20th.
   
    ```
    [language en] Page table      (0:06h)
-   [language en] Pagelinks table (1:10h)
+   [language en] Pagelinks table (1:00h)
    [language en] langlinks table (0:01h)
    [language en] redirect table  (0:01h)
    ```
@@ -290,7 +290,7 @@ uncommon for an export starting Jan/1st to only be full ready Jan/20th.
    ```
    enpage             |  17,211,555 rows | 946 MB
    enpagelinkcount    |  27,792,966 rows | 2164 MB
-   enpagelinks        | 846,265,838 rows | 42 GB
+   enpagelinks        |  61,310,384 rows | 3351 MB
    enredirect         |  10,804,606 rows | 599 MB
    ```
 
@@ -300,8 +300,7 @@ uncommon for an export starting Jan/1st to only be full ready Jan/20th.
    data fits into RAM.
 
    ```
-   Process language tables and associated pagelink counts (1:00h)
-   set counts                                             (1:00h)
+   set counts                                             (0:15h)
    add underscores to langlinks.ll_title                  (0:20h)
    set othercounts                                        (2:30h)
    Create and fill wikipedia_article_full                 (0.03h)

--- a/bin/filter_pagelinks.py
+++ b/bin/filter_pagelinks.py
@@ -8,14 +8,20 @@ Input from STDIN
     #   `pl_title`           varbinary(255)     NOT NULL DEFAULT '',
     #   `pl_from_namespace`  int(11)            NOT NULL DEFAULT 0,
 
-Output to STDOUT: only pl_title
+Output to STDOUT: pl_title, count
 '''
 
 import sys
 import csv
 
 reader = csv.DictReader(sys.stdin, fieldnames=['pl_from', 'pl_namespace', 'pl_title', 'pl_from_namespace'])
-writer = csv.DictWriter(sys.stdout, fieldnames=['title'], dialect='unix', quoting=csv.QUOTE_MINIMAL)
+writer = csv.DictWriter(sys.stdout, fieldnames=['title', 'count'], dialect='unix', quoting=csv.QUOTE_MINIMAL)
+
+# Similar to 'uniq -c' we look if the title repeats and print a count.
+# If the file is unsorted then a title might repeat later in the output. For enwiki though
+# the simply 'uniq -c' already cuts the output by 90%
+prev_title = None
+count = 0
 
 for row in reader:
     # 0 are articles
@@ -26,4 +32,12 @@ for row in reader:
     if len(title) == 0:
         continue
 
-    writer.writerow({'title': title})
+    if prev_title is not None and prev_title != title:
+        writer.writerow({'title': prev_title, 'count': count})
+        count = 0
+
+    prev_title = title
+    count += 1
+
+if prev_title is not None:
+    writer.writerow({'title': prev_title, 'count': count})

--- a/steps/wikipedia_import.sh
+++ b/steps/wikipedia_import.sh
@@ -45,10 +45,11 @@ do
 
     echo "DROP TABLE IF EXISTS ${LANG}pagelinks;" | psqlcmd
     echo "CREATE TABLE ${LANG}pagelinks (
-            pl_title          text
+            pl_title          text,
+            count             integer
         );" | psqlcmd
 
-    echo "COPY ${LANG}pagelinks (pl_title)
+    echo "COPY ${LANG}pagelinks (pl_title, count)
         FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$LANG/pagelinks.csv.gz'
         CSV
         ;" | psqlcmd

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -51,7 +51,7 @@ do
     echo "CREATE TABLE ${LANG}pagelinkcount
           AS
           SELECT pl_title AS title,
-                 COUNT(*) AS langcount,
+                 SUM(count) AS langcount,
                  0::bigint as othercount
           FROM ${LANG}pagelinks
           GROUP BY pl_title

--- a/steps/wikipedia_sql2csv.sh
+++ b/steps/wikipedia_sql2csv.sh
@@ -55,7 +55,7 @@ do
     # English wikipedia:
     #   input 6.8GB compressed (54GB uncompressed)
     #   output 450MB compressed (3.1GB uncompressed)
-    # Output columns: pl_title
+    # Output columns: pl_title, count
 
     unpigz -c $DOWNLOADED_PATH/${LANG}/pagelinks.sql.gz | \
     python3 bin/mysqldump_to_csv.py | \

--- a/tests/filter_pagelinks.test1.txt
+++ b/tests/filter_pagelinks.test1.txt
@@ -1,0 +1,9 @@
+enwiki,0,a,0
+enwiki,0,a,0
+enwiki,0,a,0
+enwiki,0,b,0
+enwiki,0,b,0
+enwiki,0,"title,with,comma",0
+enwiki,0,a,0
+enwiki,0,a,0
+enwiki,0,d,0

--- a/tests/filter_pagelinks.test1expected.txt
+++ b/tests/filter_pagelinks.test1expected.txt
@@ -1,0 +1,5 @@
+a,3
+b,2
+"title,with,comma",1
+a,2
+d,1

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+cat tests/filter_pagelinks.test1.txt | bin/filter_pagelinks.py > out.txt
+diff --brief out.txt tests/filter_pagelinks.test1expected.txt || exit 1
+
 cat tests/filter_wikidata_geo_tags.test1.txt | bin/filter_wikidata_geo_tags.py > out.txt
 diff --brief out.txt tests/filter_wikidata_geo_tags.test1expected.txt || exit 1


### PR DESCRIPTION
First part of https://github.com/osm-search/wikipedia-wikidata/issues/41

The pagelinks input table repeats titles, in postgresql they were counted `select title, count(*) group by title`.

Now the `filter_pagelinks.py` script already identifies duplicate lines and adds a `count` column. The SQL becomes `select title,sum(count) group by title`.

It cuts the number of rows to be imported into the database massively. For English from 853,792,867 to 61,310,384 (-93%). And cuts the database size in half (360GB -> 180GB).

It's possible to further optimize later. The pagelinks input isn't sorted so the output of `filter_pagelinks.py` might have a line `Paris,150` and then later another `Paris,37`. For English it would be a reduction from to 61,310,384 to 27,853,272 database rows (-55%). Sorting the output and processing it again has a cost, too. 3 minutes. Or possibly 1 minute with `sort --buffer-size 2G` (English 61,310,384  rows are about 1.3GB uncompressed).