### PR TITLE
move adding underscores to langlinks to filter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,6 @@ uncommon for an export starting Jan/1st to only be full ready Jan/20th.
 
    ```
    set counts                                             (0:15h)
-   add underscores to langlinks.ll_title                  (0:20h)
    set othercounts                                        (2:30h)
    Create and fill wikipedia_article_full                 (0.03h)
    Create derived tables                                  (0.03h)

--- a/bin/filter_langlinks.py
+++ b/bin/filter_langlinks.py
@@ -12,9 +12,15 @@ Output to STDOUT: ll_title, ll_from_page_id, ll_lang
 
 import sys
 
+# We don't need CSV parsing here because the first two columns never
+# contain commas.
 for line in sys.stdin:
     line = line.rstrip().replace('\r', '')
 
     columns = line.split(',', 2)
 
-    print(','.join([columns[2], columns[0], columns[1]]))
+    # langlinks table contain titles with spaces, e.g. 'one (two)' while pages and
+    # pagelinkcount table contain titles with underscore, e.g. 'one_(two)'
+    title = columns[2].replace(' ', '_')
+
+    print(','.join([title, columns[0], columns[1]]))

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -59,15 +59,6 @@ do
 done
 
 
-echo "add underscores to langlinks.ll_title"
-# langlinks table contain titles with spaces, e.g. 'one (two)' while pages and
-# pagelinkcount table contain titles with underscore, e.g. 'one_(two)'
-for LANG in "${LANGUAGES_ARRAY[@]}"
-do
-    echo "UPDATE ${LANG}langlinks SET ll_title = REPLACE(ll_title, ' ', '_')
-         ;" | psqlcmd
-done
-
 echo "set othercounts"
 for LANG in "${LANGUAGES_ARRAY[@]}"
 do

--- a/tests/filter_langlinks.test1.txt
+++ b/tests/filter_langlinks.test1.txt
@@ -1,0 +1,6 @@
+2074847,az,Berlin dövlət kitabxanası
+291145,az,Berlin döyüşü (1945)
+52637892,az,Berlin hücumu (2016)
+494808,az,Berlin kafedralı
+438617,az,Berlin konqresi
+1234,de,"Berlin, Berlin"

--- a/tests/filter_langlinks.test1expected.txt
+++ b/tests/filter_langlinks.test1expected.txt
@@ -1,0 +1,6 @@
+Berlin_dövlət_kitabxanası,2074847,az
+Berlin_döyüşü_(1945),291145,az
+Berlin_hücumu_(2016),52637892,az
+Berlin_kafedralı,494808,az
+Berlin_konqresi,438617,az
+"Berlin,_Berlin",1234,de

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2,5 +2,8 @@
 cat tests/filter_pagelinks.test1.txt | bin/filter_pagelinks.py > out.txt
 diff --brief out.txt tests/filter_pagelinks.test1expected.txt || exit 1
 
+cat tests/filter_langlinks.test1.txt | bin/filter_langlinks.py > out.txt
+diff --brief out.txt tests/filter_langlinks.test1expected.txt || exit 1
+
 cat tests/filter_wikidata_geo_tags.test1.txt | bin/filter_wikidata_geo_tags.py > out.txt
 diff --brief out.txt tests/filter_wikidata_geo_tags.test1expected.txt || exit 1


### PR DESCRIPTION
langlinks input table contains spaces in titles instead of underscore. We already added the underscore with SQL but it's probably faster in the sql2csv step.