### PR TITLE
mysqldump_to_csv: edgecase where last row starts with bracket

### DIFF
--- a/bin/mysqldump_to_csv.py
+++ b/bin/mysqldump_to_csv.py
@@ -71,7 +71,7 @@ def parse_values(values, outfile):
                     # as:
                     #    1) the previous entry ended in a )
                     #    2) the current entry starts with a (
-                    if latest_row[-1][-1] == ")":
+                    if (latest_row[-1] and latest_row[-1][-1] == ")"):
                         # Remove the close paren.
                         latest_row[-1] = latest_row[-1][:-1]
                         new_row = True


### PR DESCRIPTION
After the https://github.com/osm-search/wikipedia-wikidata/pull/67 change there seem to be an edge-case when the first character of a value starts with '('.

```
     if latest_row[-1][-1] == ")":
 IndexError: string index out of range
```

Example data from German redirect file below. Previously we didn't see an error because the previous value was filled with ^A instead of empty. 

```
4588104,3,Ärsäbät,,
4588112,2,Kaizen77/Farbe1,,
4588129,0,Bishop_Lloyd’s_House,,
4588148,12,Benutzer,,(Automatisch) bestätigter Benutzer
4588150,0,Profos,,
4588152,0,Universidade_Estadual_Paulista,,
4588153,0,Kloster_St._Walburg,,
```