### PR TITLE
filter_pagelinks.py counts in memory, pagelinks tables obsolete

### DIFF
--- a/bin/filter_pagelinks.py
+++ b/bin/filter_pagelinks.py
@@ -17,12 +17,7 @@ import csv
 reader = csv.reader(sys.stdin)
 writer = csv.writer(sys.stdout, dialect='unix', quoting=csv.QUOTE_MINIMAL)
 
-# Similar to 'uniq -c' we look if the title repeats and print a count.
-# If the file is unsorted then a title might repeat later in the output. For enwiki though
-# the simply 'uniq -c' already cuts the output by 90%
-prev_title = None
-count = 0
-
+counts = {}
 for row in reader:
     # pl_namespace: 0 are articles
     if (row[1] != '0'):
@@ -32,12 +27,11 @@ for row in reader:
     if len(title) == 0:
         continue
 
-    if prev_title is not None and prev_title != title:
-        writer.writerow([prev_title, count])
-        count = 0
+    if title not in counts:
+        counts[title] = 1
+    else:
+        counts[title] += 1
 
-    prev_title = title
-    count += 1
-
-if prev_title is not None:
-    writer.writerow([prev_title, count])
+# for title in sorted(counts.keys()):
+for title in counts.keys():
+    writer.writerow([title, counts[title]])

--- a/steps/wikipedia_import.sh
+++ b/steps/wikipedia_import.sh
@@ -46,10 +46,11 @@ do
     echo "DROP TABLE IF EXISTS ${LANG}pagelinks;" | psqlcmd
     echo "CREATE TABLE ${LANG}pagelinks (
             pl_title          text,
-            count             integer
+            langcount         integer,
+            othercount        integer DEFAULT 0
         );" | psqlcmd
 
-    echo "COPY ${LANG}pagelinks (pl_title, count)
+    echo "COPY ${LANG}pagelinks (pl_title, langcount)
         FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$LANG/pagelinks.csv.gz'
         CSV
         ;" | psqlcmd

--- a/steps/wikipedia_sql2csv.sh
+++ b/steps/wikipedia_sql2csv.sh
@@ -38,7 +38,7 @@ do
     #   output 190MB compressed
     # Output columns: page_id, page_title
 
-    unpigz -c $DOWNLOADED_PATH/${LANG}/page.sql.gz | \
+    unpigz -c $DOWNLOADED_PATH/$LANG/page.sql.gz | \
     ./bin/mysqldump_to_csv.py | \
     bin/filter_page.py | \
     pigz -9 > $CONVERTED_PATH/$LANG/pages.csv.gz
@@ -57,9 +57,9 @@ do
     #   output 450MB compressed (3.1GB uncompressed)
     # Output columns: pl_title, count
 
-    unpigz -c $DOWNLOADED_PATH/${LANG}/pagelinks.sql.gz | \
+    unpigz -c $DOWNLOADED_PATH/$LANG/pagelinks.sql.gz | \
     ./bin/mysqldump_to_csv.py | \
-    bin/filter_pagelinks.py | \
+    /usr/bin/time -v bin/filter_pagelinks.py | \
     pigz -9 > $CONVERTED_PATH/$LANG/pagelinks.csv.gz
 
 
@@ -95,7 +95,7 @@ do
     #   input 140MB compressed (530MB uncompressed)
     #   output 100MB compressed (300MB uncompressed)
 
-    unpigz -c $DOWNLOADED_PATH/${LANG}/redirect.sql.gz | \
+    unpigz -c $DOWNLOADED_PATH/$LANG/redirect.sql.gz | \
     ./bin/mysqldump_to_csv.py | \
     bin/filter_redirect.py | \
     pigz -9 > $CONVERTED_PATH/$LANG/redirect.csv.gz

--- a/tests/filter_pagelinks.test1expected.txt
+++ b/tests/filter_pagelinks.test1expected.txt
@@ -1,5 +1,4 @@
-a,3
+a,5
 b,2
 "title,with,comma",1
-a,2
 d,1


### PR DESCRIPTION
closes https://github.com/osm-search/wikipedia-wikidata/issues/41

follow-up to https://github.com/osm-search/wikipedia-wikidata/pull/69

Instead of sorting the output `filter_pagelinks.py` and summarizing the counts after the sort, now the script sorts in-memory. For English wikipedia page this 3.8 GB memory, still reasonable these days.

The `${lang}pagelinkcount` tables are no longer needed. Saves about 10GB database size (103 -> 88GB). Also the CSV files are smaller: 294m rows for all languages before, now 174m (-40%).

Overall time taken about the same.