### PR TITLE
dont use shell variable named -LANG-

### DIFF
--- a/steps/cleanup.sh
+++ b/steps/cleanup.sh
@@ -18,13 +18,13 @@ echo "====================================================================="
 echo "Dropping intermediate wikipedia tables to conserve space"
 echo "====================================================================="
 
-for LANG in "${LANGUAGES_ARRAY[@]}"
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"
 do
-    echo "DROP TABLE ${LANG}pagelinks;"     | psqlcmd
-    echo "DROP TABLE ${LANG}page;"          | psqlcmd
-    echo "DROP TABLE ${LANG}langlinks;"     | psqlcmd
-    echo "DROP TABLE ${LANG}redirect;"      | psqlcmd
-    echo "DROP TABLE ${LANG}pagelinkcount;" | psqlcmd
+    echo "DROP TABLE ${WIKILANG}pagelinks;"     | psqlcmd
+    echo "DROP TABLE ${WIKILANG}page;"          | psqlcmd
+    echo "DROP TABLE ${WIKILANG}langlinks;"     | psqlcmd
+    echo "DROP TABLE ${WIKILANG}redirect;"      | psqlcmd
+    echo "DROP TABLE ${WIKILANG}pagelinkcount;" | psqlcmd
 done
 
 
@@ -34,7 +34,7 @@ echo "====================================================================="
 
 echo "DROP TABLE wikidata_place_dump;" | psqlcmd
 echo "DROP TABLE geo_earth_primary;"   | psqlcmd
-for LANG in "${LANGUAGES_ARRAY[@]}"
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"
 do
-    echo "DROP TABLE wikidata_${LANG}_pages;" | psqlcmd
+    echo "DROP TABLE wikidata_${WIKILANG}_pages;" | psqlcmd
 done

--- a/steps/wikidata_process.sh
+++ b/steps/wikidata_process.sh
@@ -90,10 +90,10 @@ echo "CREATE TABLE wikidata_pages (
         language      text
       );" | psqlcmd
 
-for LANG in "${LANGUAGES_ARRAY[@]}"
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"
 do
-   echo "DROP TABLE IF EXISTS wikidata_${LANG}_pages;" | psqlcmd
-   echo "CREATE TABLE wikidata_${LANG}_pages AS
+   echo "DROP TABLE IF EXISTS wikidata_${WIKILANG}_pages;" | psqlcmd
+   echo "CREATE TABLE wikidata_${WIKILANG}_pages AS
          SELECT wikidata_places.item,
                 wikidata_places.instance_of,
                 wikidata_places.lat,
@@ -102,7 +102,7 @@ do
          FROM wikidata_places
          LEFT JOIN wb_items_per_site
                 ON (CAST (( LTRIM(wikidata_places.item, 'Q')) AS INTEGER) = wb_items_per_site.ips_item_id)
-         WHERE ips_site_id = '${LANG}wiki'
+         WHERE ips_site_id = '${WIKILANG}wiki'
          ORDER BY wikidata_places.item
          ;" | psqlcmd
 
@@ -112,8 +112,8 @@ do
                 lat,
                 lon,
                 REPLACE(ips_site_page, ' ', '_') as wp_page_title,
-                '${LANG}'
-         FROM wikidata_${LANG}_pages
+                '${WIKILANG}'
+         FROM wikidata_${WIKILANG}_pages
          ;" | psqlcmd
 done
 

--- a/steps/wikipedia_download.sh
+++ b/steps/wikipedia_download.sh
@@ -33,10 +33,10 @@ download() {
     du -h "$2" | cut -f1
 }
 
-for LANG in "${LANGUAGES_ARRAY[@]}"; do
-    echo "Language: $LANG"
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"; do
+    echo "Language: $WIKILANG"
 
-    mkdir -p "$DOWNLOADED_PATH/$LANG"
+    mkdir -p "$DOWNLOADED_PATH/$WIKILANG"
 
     # English is the largest
     # 2.1G  downloaded/en/page.sql.gz
@@ -54,14 +54,14 @@ for LANG in "${LANGUAGES_ARRAY[@]}"; do
 
     for FN in page.sql.gz pagelinks.sql.gz langlinks.sql.gz linktarget.sql.gz redirect.sql.gz; do
 
-        download https://$WIKIMEDIA_HOST/${LANG}wiki/$WIKIPEDIA_DATE/${LANG}wiki-$WIKIPEDIA_DATE-$FN "$DOWNLOADED_PATH/$LANG/$FN"
-        download https://$WIKIMEDIA_HOST/${LANG}wiki/$WIKIPEDIA_DATE/md5sums-${LANG}wiki-$WIKIPEDIA_DATE-$FN.txt "$DOWNLOADED_PATH/$LANG/$FN.md5"
+        download https://$WIKIMEDIA_HOST/${WIKILANG}wiki/$WIKIPEDIA_DATE/${WIKILANG}wiki-$WIKIPEDIA_DATE-$FN "$DOWNLOADED_PATH/$WIKILANG/$FN"
+        download https://$WIKIMEDIA_HOST/${WIKILANG}wiki/$WIKIPEDIA_DATE/md5sums-${WIKILANG}wiki-$WIKIPEDIA_DATE-$FN.txt "$DOWNLOADED_PATH/$WIKILANG/$FN.md5"
 
-        EXPECTED_MD5=$(cat "$DOWNLOADED_PATH/$LANG/$FN.md5" | cut -d\  -f1)
-        CALCULATED_MD5=$(md5sum "$DOWNLOADED_PATH/$LANG/$FN" | cut -d\  -f1)
+        EXPECTED_MD5=$(cat "$DOWNLOADED_PATH/$WIKILANG/$FN.md5" | cut -d\  -f1)
+        CALCULATED_MD5=$(md5sum "$DOWNLOADED_PATH/$WIKILANG/$FN" | cut -d\  -f1)
 
         if [[ "$EXPECTED_MD5" != "$CALCULATED_MD5" ]]; then
-            echo "$FN for language $LANG - md5 checksum doesn't match, download broken"
+            echo "$FN for language $WIKILANG - md5 checksum doesn't match, download broken"
             exit 1
         fi
     done

--- a/steps/wikipedia_import.sh
+++ b/steps/wikipedia_import.sh
@@ -19,70 +19,70 @@ echo "====================================================================="
 echo "Import wikipedia CSV tables"
 echo "====================================================================="
 
-for LANG in "${LANGUAGES_ARRAY[@]}"
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"
 do
-    echo "$LANG"
+    echo "$WIKILANG"
 
     # -----------------------------------------------------------
-    echo "* ${LANG}page from $CONVERTED_PATH_ABS/$LANG/pages.csv.gz";
+    echo "* ${WIKILANG}page from $CONVERTED_PATH_ABS/$WIKILANG/pages.csv.gz";
 
-    echo "DROP TABLE IF EXISTS ${LANG}page;" | psqlcmd
-    echo "CREATE TABLE ${LANG}page (
+    echo "DROP TABLE IF EXISTS ${WIKILANG}page;" | psqlcmd
+    echo "CREATE TABLE ${WIKILANG}page (
             page_id            integer,
             page_title         text
         );" | psqlcmd
 
 
-    echo "COPY ${LANG}page (page_id, page_title)
-        FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$LANG/pages.csv.gz'
+    echo "COPY ${WIKILANG}page (page_id, page_title)
+        FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$WIKILANG/pages.csv.gz'
         CSV
         ;" | psqlcmd
 
 
 
     # -----------------------------------------------------------
-    echo "* ${LANG}pagelinks from $CONVERTED_PATH_ABS/$LANG/pagelinks.csv.gz";
+    echo "* ${WIKILANG}pagelinks from $CONVERTED_PATH_ABS/$WIKILANG/pagelinks.csv.gz";
 
-    echo "DROP TABLE IF EXISTS ${LANG}pagelinks;" | psqlcmd
-    echo "CREATE TABLE ${LANG}pagelinks (
+    echo "DROP TABLE IF EXISTS ${WIKILANG}pagelinks;" | psqlcmd
+    echo "CREATE TABLE ${WIKILANG}pagelinks (
             pl_title          text,
             langcount         integer,
             othercount        integer DEFAULT 0
         );" | psqlcmd
 
-    echo "COPY ${LANG}pagelinks (pl_title, langcount)
-        FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$LANG/pagelinks.csv.gz'
+    echo "COPY ${WIKILANG}pagelinks (pl_title, langcount)
+        FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$WIKILANG/pagelinks.csv.gz'
         CSV
         ;" | psqlcmd
 
 
     # -----------------------------------------------------------
-    echo "* ${LANG}langlinks from $CONVERTED_PATH_ABS/$LANG/langlinks.csv.gz";
+    echo "* ${WIKILANG}langlinks from $CONVERTED_PATH_ABS/$WIKILANG/langlinks.csv.gz";
 
-    echo "DROP TABLE IF EXISTS ${LANG}langlinks;" | psqlcmd
-    echo "CREATE TABLE ${LANG}langlinks (
+    echo "DROP TABLE IF EXISTS ${WIKILANG}langlinks;" | psqlcmd
+    echo "CREATE TABLE ${WIKILANG}langlinks (
             ll_from    integer,
             ll_lang    text,
             ll_title   text
         );" | psqlcmd
 
-    echo "COPY ${LANG}langlinks (ll_title, ll_from, ll_lang)
-        FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$LANG/langlinks.csv.gz'
+    echo "COPY ${WIKILANG}langlinks (ll_title, ll_from, ll_lang)
+        FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$WIKILANG/langlinks.csv.gz'
         CSV
         ;" | psqlcmd
 
 
     # -----------------------------------------------------------
-    echo "* ${LANG}redirect from $CONVERTED_PATH_ABS/$LANG/redirects.csv.gz";
+    echo "* ${WIKILANG}redirect from $CONVERTED_PATH_ABS/$WIKILANG/redirects.csv.gz";
 
-    echo "DROP TABLE IF EXISTS ${LANG}redirect;" | psqlcmd
-    echo "CREATE TABLE ${LANG}redirect (
+    echo "DROP TABLE IF EXISTS ${WIKILANG}redirect;" | psqlcmd
+    echo "CREATE TABLE ${WIKILANG}redirect (
             rd_from    integer,
             rd_title   text
         );" | psqlcmd
 
-    echo "COPY ${LANG}redirect (rd_from, rd_title)
-        FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$LANG/redirect.csv.gz'
+    echo "COPY ${WIKILANG}redirect (rd_from, rd_title)
+        FROM PROGRAM 'unpigz -c $CONVERTED_PATH_ABS/$WIKILANG/redirect.csv.gz'
         CSV
         ;" | psqlcmd
 

--- a/steps/wikipedia_process.sh
+++ b/steps/wikipedia_process.sh
@@ -23,14 +23,14 @@ echo "CREATE TABLE wikipedia_redirect_full (
         to_title   text
      );" | psqlcmd
 
-for LANG in "${LANGUAGES_ARRAY[@]}"
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"
 do
     echo "INSERT INTO wikipedia_redirect_full
-          SELECT '${LANG}',
+          SELECT '${WIKILANG}',
                  page_title,
                  rd_title
-          FROM ${LANG}redirect
-          JOIN ${LANG}page ON (rd_from = page_id)
+          FROM ${WIKILANG}redirect
+          JOIN ${WIKILANG}page ON (rd_from = page_id)
           ;" | psqlcmd
 done
 
@@ -45,26 +45,26 @@ echo "====================================================================="
 echo "set othercounts"
 # Creating indexes on title, ll_title didn't have any positive effect on
 # query performance and added another 1 hour and 35GB of data.
-# echo "CREATE INDEX idx_${LANG}langlinks ON ${LANG}langlinks (ll_lang, ll_title);" | psqlcmd
-# echo "CREATE INDEX idx_${LANG}langlinks2 ON ${LANG}langlinks (ll_title);" | psqlcmd
-# echo "CREATE INDEX idx_${LANG}page ON ${LANG}page (page_id);" | psqlcmd
-# echo "CREATE INDEX idx_${LANG}page2 ON ${LANG}page (page_title);" | psqlcmd
-for LANG in "${LANGUAGES_ARRAY[@]}"
+# echo "CREATE INDEX idx_${WIKILANG}langlinks ON ${WIKILANG}langlinks (ll_lang, ll_title);" | psqlcmd
+# echo "CREATE INDEX idx_${WIKILANG}langlinks2 ON ${WIKILANG}langlinks (ll_title);" | psqlcmd
+# echo "CREATE INDEX idx_${WIKILANG}page ON ${WIKILANG}page (page_id);" | psqlcmd
+# echo "CREATE INDEX idx_${WIKILANG}page2 ON ${WIKILANG}page (page_title);" | psqlcmd
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"
 do
-    echo "Language: $LANG"
+    echo "Language: $WIKILANG"
 
     for OTHERLANG in "${LANGUAGES_ARRAY[@]}"
     do
-        echo "UPDATE ${LANG}pagelinks
+        echo "UPDATE ${WIKILANG}pagelinks
               SET othercount = othercount + x.count
               FROM (
-                SELECT ${LANG}page.page_title AS title,
+                SELECT ${WIKILANG}page.page_title AS title,
                        ${OTHERLANG}pagelinks.langcount AS count
-                FROM ${LANG}langlinks
-                JOIN ${LANG}page ON (ll_from = page_id)
+                FROM ${WIKILANG}langlinks
+                JOIN ${WIKILANG}page ON (ll_from = page_id)
                 JOIN ${OTHERLANG}pagelinks ON (ll_lang = '${OTHERLANG}' AND ll_title = pl_title)
               ) AS x
-              WHERE x.title = ${LANG}pagelinks.pl_title
+              WHERE x.title = ${WIKILANG}pagelinks.pl_title
               ;" | psqlcmd
     done
 
@@ -91,15 +91,15 @@ echo "CREATE TABLE wikipedia_article_full (
         instance_of    text
       );" | psqlcmd
 
-for LANG in "${LANGUAGES_ARRAY[@]}"
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"
 do
     echo "INSERT INTO wikipedia_article_full
-          SELECT '${LANG}',
+          SELECT '${WIKILANG}',
                  pl_title,
                  langcount,
                  othercount,
                  langcount + othercount
-          FROM ${LANG}pagelinks
+          FROM ${WIKILANG}pagelinks
           ;" | psqlcmd
 done
 

--- a/steps/wikipedia_sql2csv.sh
+++ b/steps/wikipedia_sql2csv.sh
@@ -12,11 +12,11 @@ echo "====================================================================="
 echo "Convert Wikipedia language tables"
 echo "====================================================================="
 
-for LANG in "${LANGUAGES_ARRAY[@]}"
+for WIKILANG in "${LANGUAGES_ARRAY[@]}"
 do
-    mkdir -p "$CONVERTED_PATH/$LANG/"
+    mkdir -p "$CONVERTED_PATH/$WIKILANG/"
 
-    echo "[language $LANG] Page table SQL => CSV"
+    echo "[language $WIKILANG] Page table SQL => CSV"
     # https://www.mediawiki.org/wiki/Manual:Page_table
     #
     # CREATE TABLE `page` (
@@ -39,13 +39,13 @@ do
     #   output 200MB compressed
     # Output columns: page_id, page_title
 
-    unpigz -c $DOWNLOADED_PATH/$LANG/page.sql.gz | \
+    unpigz -c $DOWNLOADED_PATH/$WIKILANG/page.sql.gz | \
     bin/mysqldump_to_csv.py | \
     bin/filter_page.py | \
-    pigz -9 > $CONVERTED_PATH/$LANG/pages.csv.gz
+    pigz -9 > $CONVERTED_PATH/$WIKILANG/pages.csv.gz
 
 
-    echo "[language $LANG] linktarget table SQL => CSV"
+    echo "[language $WIKILANG] linktarget table SQL => CSV"
     # https://www.mediawiki.org/wiki/Manual:Linktarget_table
     #
     # CREATE TABLE `linktarget` (
@@ -59,14 +59,14 @@ do
     #   output 322MB compressed (30m rows)
     # Output columns: lt_id, lt_title
 
-    unpigz -c $DOWNLOADED_PATH/${LANG}/linktarget.sql.gz | \
+    unpigz -c $DOWNLOADED_PATH/${WIKILANG}/linktarget.sql.gz | \
     bin/mysqldump_to_csv.py | \
     bin/filter_redirect.py  | \
-    pigz -9 > $CONVERTED_PATH/$LANG/linktarget.csv.gz
+    pigz -9 > $CONVERTED_PATH/$WIKILANG/linktarget.csv.gz
 
 
 
-    echo "[language $LANG] Pagelinks table SQL => CSV"
+    echo "[language $WIKILANG] Pagelinks table SQL => CSV"
     # https://www.mediawiki.org/wiki/Manual:Pagelinks_table
     #
     # CREATE TABLE `pagelinks` (
@@ -80,13 +80,13 @@ do
     #   output 200MB compressed
     # Output columns: lt_title (from linktarget file), count (unique pl_from)
 
-    unpigz -c $DOWNLOADED_PATH/$LANG/pagelinks.sql.gz | \
+    unpigz -c $DOWNLOADED_PATH/$WIKILANG/pagelinks.sql.gz | \
     bin/mysqldump_to_csv.py | \
-    bin/filter_pagelinks.py $CONVERTED_PATH/$LANG/linktarget.csv.gz | \
-    pigz -9 > $CONVERTED_PATH/$LANG/pagelinks.csv.gz
+    bin/filter_pagelinks.py $CONVERTED_PATH/$WIKILANG/linktarget.csv.gz | \
+    pigz -9 > $CONVERTED_PATH/$WIKILANG/pagelinks.csv.gz
 
 
-    echo "[language $LANG] langlinks table SQL => CSV"
+    echo "[language $WIKILANG] langlinks table SQL => CSV"
     # https://www.mediawiki.org/wiki/Manual:Langlinks_table
     #
     # CREATE TABLE `langlinks` (
@@ -100,15 +100,15 @@ do
     #   input 400MB compressed (1.5GB uncompressed)
     #   output 310MB compressed (1.3GB uncompressed)
 
-    unpigz -c $DOWNLOADED_PATH/${LANG}/langlinks.sql.gz | \
+    unpigz -c $DOWNLOADED_PATH/${WIKILANG}/langlinks.sql.gz | \
     bin/mysqldump_to_csv.py | \
     bin/filter_langlinks.py | \
-    pigz -9 > $CONVERTED_PATH/$LANG/langlinks.csv.gz
+    pigz -9 > $CONVERTED_PATH/$WIKILANG/langlinks.csv.gz
 
 
 
 
-    echo "[language $LANG] redirect table SQL => CSV"
+    echo "[language $WIKILANG] redirect table SQL => CSV"
     # https://www.mediawiki.org/wiki/Manual:Redirect_table
     #
     # CREATE TABLE `redirect` (
@@ -124,10 +124,10 @@ do
     #   input 140MB compressed (530MB uncompressed)
     #   output 120MB compressed (300MB uncompressed)
 
-    unpigz -c $DOWNLOADED_PATH/$LANG/redirect.sql.gz | \
+    unpigz -c $DOWNLOADED_PATH/$WIKILANG/redirect.sql.gz | \
     bin/mysqldump_to_csv.py | \
     bin/filter_redirect.py | \
-    pigz -9 > $CONVERTED_PATH/$LANG/redirect.csv.gz
+    pigz -9 > $CONVERTED_PATH/$WIKILANG/redirect.csv.gz
 
-    du -h $CONVERTED_PATH/$LANG/*
+    du -h $CONVERTED_PATH/$WIKILANG/*
 done


### PR DESCRIPTION
`LANG` in Linux is the standard libc environment variable for locale. Setting it in our loops caused many warnings. Thus we rename it in our scripts.

```
  [00:48:59] * arpage from /wikipedia-wikidata/wikimedia_build_20260404/converted/wikipedia/ar/pages.csv.gz
  [00:48:59] perl: warning: Setting locale failed.
  [00:48:59] perl: warning: Please check that your locale settings:
  [00:48:59]     LANGUAGE = (unset),
  [00:48:59]     LC_ALL = (unset),
  [00:48:59]     LANG = "ar"
  [00:48:59]     are supported and installed on your system.```
```