### PR TITLE
retry downloads, but exit early on failure

### DIFF
--- a/complete_run.sh
+++ b/complete_run.sh
@@ -7,7 +7,23 @@
 # Example to add timestamps and create a logfile:
 # time ./complete_run.sh 2>&1 | ts -s "[%H:%M:%S]" | tee "$(date +"%Y%m%d").$$.log"
 
-./install_dependencies.sh
+# Inspect exit code of each step. 'set -e' or '|| exit' would also work but
+# with a function we have more verbose logging.
+run_step() {
+    # $* and $@ are both all positional parameter to this function
+    # $* is string representation
+    # $@ is an array, what actually gets run
+    echo "===> Running: $*"
+    "$@"
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        echo "STEP FAILED (exit $status): $*"
+        echo "Aborting run."
+        exit "$status"
+    fi
+}
+
+run_step ./install_dependencies.sh
 
 # checks https://wikidata.aerotechnet.com/enwiki/
 #    and https://wikidata.aerotechnet.com/wikidatawiki/
@@ -26,23 +42,25 @@ export LANGUAGES=$(grep -v '^#' config/languages.txt | tr "\n" ",")
 # export LANGUAGES=de,nl
 export DATABASE_NAME=$BUILDID
 
-./steps/wikipedia_download.sh
-./steps/wikidata_download.sh
-./steps/wikidata_api_fetch_placetypes.sh
+run_step ./steps/wikipedia_download.sh
+run_step ./steps/wikidata_download.sh
+run_step ./steps/wikidata_api_fetch_placetypes.sh
 
-./steps/wikipedia_sql2csv.sh
-./steps/wikidata_sql2csv.sh
+run_step ./steps/wikipedia_sql2csv.sh
+run_step ./steps/wikidata_sql2csv.sh
 
 # dropdb --if-exists $DATABASE_NAME
+# createdb is expected to fail on a re-run (DB already exists), so it is
+# intentionally not wrapped in run_step.
 createdb $DATABASE_NAME
-./steps/wikipedia_import.sh
-./steps/wikidata_import.sh
+run_step ./steps/wikipedia_import.sh
+run_step ./steps/wikidata_import.sh
 
-./steps/wikipedia_process.sh
-./steps/wikidata_process.sh
+run_step ./steps/wikipedia_process.sh
+run_step ./steps/wikidata_process.sh
 
-./steps/report_database_size.sh
-./steps/output.sh
+run_step ./steps/report_database_size.sh
+run_step ./steps/output.sh
 # ./steps/cleanup.sh
 
 echo "Finished."

--- a/steps/wikidata_download.sh
+++ b/steps/wikidata_download.sh
@@ -11,6 +11,10 @@ echo "====================================================================="
 : ${WIKIMEDIA_HOST:=wikidata.aerotechnet.com}
 # See list on https://wikidata.aerotechnet.com/wikidatawiki/
 : ${WIKIDATA_DATE:=20220701}
+# An empty download usually means the mirror has not synced that file yet.
+# Retry a few times before giving up.
+: ${DOWNLOAD_MAX_ATTEMPTS:=5}
+: ${DOWNLOAD_RETRY_WAIT:=3600} # 1 hour, to give the mirror time to sync
 
 DOWNLOADED_PATH="$BUILDID/downloaded/wikidata"
 mkdir -p $DOWNLOADED_PATH
@@ -22,12 +26,23 @@ download() {
         return
     fi
     header='--header=User-Agent:Osm-search-Bot/1(https://github.com/osm-search/wikipedia-wikidata)'
-    wget -O "$2" --quiet $header --no-clobber --tries=3 "$1"
-    if [ ! -s "$2" ]; then
-        echo "downloaded file $2 is empty, please retry later"
+
+    for attempt in $(seq 1 "$DOWNLOAD_MAX_ATTEMPTS"); do
+        wget -O "$2" --quiet $header --no-clobber --tries=3 "$1"
+        if [ -s "$2" ]; then
+            du -h "$2" | cut -f1
+            return
+        fi
+        echo "downloaded file $2 is empty (attempt $attempt/$DOWNLOAD_MAX_ATTEMPTS)"
         rm -f "$2"
-        exit 1
-    fi
+        if [ "$attempt" -lt "$DOWNLOAD_MAX_ATTEMPTS" ]; then
+            echo "mirror may not have synced this file yet, retrying in ${DOWNLOAD_RETRY_WAIT}s ..."
+            sleep "$DOWNLOAD_RETRY_WAIT"
+        fi
+    done
+
+    echo "downloaded file $2 is still empty after $DOWNLOAD_MAX_ATTEMPTS attempts, giving up"
+    exit 1
 }
 
 for FN in geo_tags.sql.gz page.sql.gz wb_items_per_site.sql.gz; do

--- a/steps/wikipedia_download.sh
+++ b/steps/wikipedia_download.sh
@@ -14,6 +14,10 @@ LANGUAGES_ARRAY=($(echo $LANGUAGES | tr ',' ' '))
 : ${WIKIMEDIA_HOST:=wikidata.aerotechnet.com}
 # See list on https://wikidata.aerotechnet.com/enwiki/
 : ${WIKIPEDIA_DATE:=20220620}
+# An empty download usually means the mirror has not synced that file yet.
+# Retry a few times before giving up.
+: ${DOWNLOAD_MAX_ATTEMPTS:=5}
+: ${DOWNLOAD_RETRY_WAIT:=3600} # 1 hour, to give the mirror time to sync
 
 DOWNLOADED_PATH="$BUILDID/downloaded/wikipedia"
 
@@ -24,13 +28,23 @@ download() {
         return
     fi
     header='--header=User-Agent:Osm-search-Bot/1(https://github.com/osm-search/wikipedia-wikidata)'
-    wget -O "$2" --quiet $header --no-clobber --tries=3 "$1"
-    if [ ! -s "$2" ]; then
-        echo "downloaded file $2 is empty, please retry later"
+
+    for attempt in $(seq 1 "$DOWNLOAD_MAX_ATTEMPTS"); do
+        wget -O "$2" --quiet $header --no-clobber --tries=3 "$1"
+        if [ -s "$2" ]; then
+            du -h "$2" | cut -f1
+            return
+        fi
+        echo "downloaded file $2 is empty (attempt $attempt/$DOWNLOAD_MAX_ATTEMPTS)"
         rm -f "$2"
-        exit 1
-    fi
-    du -h "$2" | cut -f1
+        if [ "$attempt" -lt "$DOWNLOAD_MAX_ATTEMPTS" ]; then
+            echo "mirror may not have synced this file yet, retrying in ${DOWNLOAD_RETRY_WAIT}s ..."
+            sleep "$DOWNLOAD_RETRY_WAIT"
+        fi
+    done
+
+    echo "downloaded file $2 is still empty after $DOWNLOAD_MAX_ATTEMPTS attempts, giving up"
+    exit 1
 }
 
 for WIKILANG in "${LANGUAGES_ARRAY[@]}"; do


### PR DESCRIPTION
If a single file is missing on the mirror server the download step croaked (`exit 1`) the other steps continued, wasting resources.